### PR TITLE
Refetch channel manifest

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,7 @@ pub enum CargoMSRVError {
     Reqwest(reqwest::Error),
     RustupInstallFailed,
     RustupRunWithCommandFailed,
+    SystemTime(std::time::SystemTimeError),
     Toml(toml::de::Error),
     ToolchainNotInstalled,
     UnknownTarget,
@@ -37,6 +38,7 @@ impl fmt::Display for CargoMSRVError {
             CargoMSRVError::RustupInstallFailed => write!(f, "Unable to install toolchain with `rustup install <toolchain>`."),
             CargoMSRVError::RustupRunWithCommandFailed => write!(f, "Check toolchain (with `rustup run <toolchain> <command>`) failed."),
             CargoMSRVError::Reqwest(err) => err.fmt(f),
+            CargoMSRVError::SystemTime(err) => err.fmt(f),
             CargoMSRVError::Toml(err) => err.fmt(f),
             CargoMSRVError::ToolchainNotInstalled => write!(f, "The given toolchain could not be found. Run `rustup toolchain list` for an overview of installed toolchains."),
             CargoMSRVError::UnknownTarget => write!(f, "The given target could not be found. Run `rustup target list` for an overview of available toolchains."),
@@ -78,6 +80,12 @@ impl From<std::num::ParseIntError> for CargoMSRVError {
 impl From<reqwest::Error> for CargoMSRVError {
     fn from(err: reqwest::Error) -> Self {
         CargoMSRVError::Reqwest(err)
+    }
+}
+
+impl From<std::time::SystemTimeError> for CargoMSRVError {
+    fn from(err: std::time::SystemTimeError) -> Self {
+        CargoMSRVError::SystemTime(err)
     }
 }
 


### PR DESCRIPTION
This is an attempt to implement #1.
It checks the modification time of the downloaded manifest file. If the file was modified more than a day ago, it is redownloaded.