### PR TITLE
Revert "Merge pull request #12 from foresterre/dependabot/cargo/indicatif-0.13.0"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.101", features = ["derive"] }
 toml = "0.5"
 
 # Used to display progression
-indicatif = "0.13.0"
+indicatif = "0.12.0"
 
 
 [[bin]]


### PR DESCRIPTION
This reverts commit ab3c4578f64528bc76fedcd1bdec793ab8d2866f, reversing
changes made to 3b7324fcbd860a61156a225ad071c3a6e4f37d37.

Build fails on Windows on unstable code in a third party dependency.