### PR TITLE
Fix bug where no output was shown to the user by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           # pinned (MSRV) rust version :: ubuntu
           - build: msrv
             os: ubuntu-18.04
-            rust: 1.40.0
+            rust: 1.42.0
 
           # latest rust stable :: ubuntu
           - build: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 clap = "2.33.0"
 
 # Used to obtain the 'channel-manifest'.
-attohttpc = "0.15.0"
+attohttpc = "0.16.1"
 
 # Used to decide where to cache the 'channel-manifest' file.
 directories = "3.0.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,7 @@ impl<'a> CmdMatches<'a> {
     }
 
     pub fn seek_path(&self) -> Option<&Path> {
-        self.seek_path.as_ref().map(|p| p.as_path())
+        self.seek_path.as_deref()
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,5 @@
 use crate::fetch::ToolchainSpecifier;
+use std::env;
 use std::error::Error;
 use std::fmt;
 use std::fmt::Formatter;
@@ -11,10 +12,12 @@ pub type TResult<T> = Result<T, CargoMSRVError>;
 pub enum CargoMSRVError {
     AttoHTTPC(attohttpc::Error),
     DefaultHostTripleNotFound,
+    Env(env::VarError),
     GenericMessage(String),
     Io(io::Error),
     InvalidRustVersionNumber(std::num::ParseIntError),
     InvalidUTF8(FromUtf8Error),
+    Log(log::ParseLevelError),
     RustupInstallFailed(ToolchainSpecifier),
     RustupRunWithCommandFailed,
     SystemTime(std::time::SystemTimeError),
@@ -44,10 +47,12 @@ impl fmt::Display for CargoMSRVError {
         match self {
             CargoMSRVError::AttoHTTPC(err) => err.fmt(f),
             CargoMSRVError::DefaultHostTripleNotFound => write!(f, "The default host triple (target) could not be found."),
+            CargoMSRVError::Env(err) => err.fmt(f),
             CargoMSRVError::GenericMessage(msg) => write!(f, "{}", msg.as_str()),
             CargoMSRVError::Io(err) => err.fmt(f),
             CargoMSRVError::InvalidRustVersionNumber(err) => err.fmt(f),
             CargoMSRVError::InvalidUTF8(err) => err.fmt(f),
+            CargoMSRVError::Log(err) => err.fmt(f),
             CargoMSRVError::RustupInstallFailed(toolchain) => f.write_fmt(format_args!("Unable to install toolchain with `rustup install {}`.", toolchain)),
             CargoMSRVError::RustupRunWithCommandFailed => write!(f, "Check toolchain (with `rustup run <toolchain> <command>`) failed."),
             CargoMSRVError::SystemTime(err) => err.fmt(f),
@@ -68,6 +73,12 @@ impl Error for CargoMSRVError {}
 impl From<String> for CargoMSRVError {
     fn from(msg: String) -> Self {
         CargoMSRVError::GenericMessage(msg)
+    }
+}
+
+impl From<env::VarError> for CargoMSRVError {
+    fn from(err: env::VarError) -> Self {
+        CargoMSRVError::Env(err)
     }
 }
 
@@ -92,6 +103,11 @@ impl From<std::num::ParseIntError> for CargoMSRVError {
 impl From<attohttpc::Error> for CargoMSRVError {
     fn from(err: attohttpc::Error) -> Self {
         CargoMSRVError::AttoHTTPC(err)
+    }
+}
+impl From<log::ParseLevelError> for CargoMSRVError {
+    fn from(err: log::ParseLevelError) -> Self {
+        CargoMSRVError::Log(err)
     }
 }
 


### PR DESCRIPTION
To see output, the variable had to be set before program execution, or by using a cargo feature; setting the variable after initialising the logger did not work properly.

fixes #39 