### PR TITLE
Refactor to provide more helpful message on cargo msrv failures

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -27,7 +27,7 @@ pub fn check_toolchain(version: RustStableVersion, config: &CmdMatches) -> TResu
         version,
         &toolchain_specifier,
         config.seek_path(),
-        config.custom_check(),
+        config.check_command(),
     )
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ impl<'a> CmdMatches<'a> {
         &self.target
     }
 
-    pub fn custom_check(&self) -> &Vec<&'a str> {
+    pub fn check_command(&self) -> &Vec<&'a str> {
         &self.check_command
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,7 +25,10 @@ pub enum CargoMSRVError {
     ToolchainNotInstalled,
     UnknownTarget,
     UnableToCacheChannelManifest,
-    UnableToFindAnyGoodVersion { latest_toolchain: String },
+    UnableToFindAnyGoodVersion {
+        latest_toolchain: String,
+        command: String,
+    },
     UnableToParseCliArgs,
     UnableToParseRustVersion,
     UnableToRunCheck,
@@ -49,14 +52,14 @@ impl fmt::Display for CargoMSRVError {
             CargoMSRVError::ToolchainNotInstalled => write!(f, "The given toolchain could not be found. Run `rustup toolchain list` for an overview of installed toolchains."),
             CargoMSRVError::UnknownTarget => write!(f, "The given target could not be found. Run `rustup target list` for an overview of available toolchains."),
             CargoMSRVError::UnableToCacheChannelManifest => write!(f, "Unable to get or store the channel manifest on disk."),
-            CargoMSRVError::UnableToFindAnyGoodVersion { latest_toolchain } => write!(f, r#"Unable to find a Minimum Supported Rust Version (MSRV).
+            CargoMSRVError::UnableToFindAnyGoodVersion { latest_toolchain, command } => write!(f, r#"Unable to find a Minimum Supported Rust Version (MSRV).
 
-If you think this result is erroneous, please run: `rustup run {} cargo build --all` manually.
+If you think this result is erroneous, please run: `rustup run {} {}` manually.
 
 If the above does succeed, or you think cargo-msrv errored in another way, please feel free to
 report the issue at: https://github.com/foresterre/cargo-msrv/issues
 
-Thank you in advance!"#, latest_toolchain.as_str()),
+Thank you in advance!"#, latest_toolchain.as_str(), command.as_str()),
             CargoMSRVError::UnableToParseCliArgs => write!(f, "Unable to parse the CLI arguments. Use `cargo msrv help` for more info."),
             CargoMSRVError::UnableToParseRustVersion => write!(f, "The Rust stable version could not be parsed from the stable channel manifest."),
             CargoMSRVError::UnableToRunCheck => write!(f, "Unable to run the checking command. If --check <cmd> is specified, you could try to verify if you can run the cmd manually." )

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,22 +25,11 @@ pub enum CargoMSRVError {
     ToolchainNotInstalled,
     UnknownTarget,
     UnableToCacheChannelManifest,
-    UnableToFindAnyGoodVersion,
+    UnableToFindAnyGoodVersion { latest_toolchain: String },
     UnableToParseCliArgs,
     UnableToParseRustVersion,
     UnableToRunCheck,
 }
-
-const NO_GOOD_VERSION_FOUND: &str = r#"Unable to find a Minimum Supported Rust Version (MSRV).
-
-If you think this result is erroneous, please run:
-`rustup run <your-toolchain> cargo build` manually, for example:
-`rustup run 1.38.0-x86_64-unknown-linux-gnu cargo build`
-
-If the above does succeed, or you think cargo-msrv errored in another way, please feel free to
-report the issue at: https://github.com/foresterre/cargo-msrv/issues
-
-Thank you in advance!"#;
 
 impl fmt::Display for CargoMSRVError {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
@@ -60,7 +49,14 @@ impl fmt::Display for CargoMSRVError {
             CargoMSRVError::ToolchainNotInstalled => write!(f, "The given toolchain could not be found. Run `rustup toolchain list` for an overview of installed toolchains."),
             CargoMSRVError::UnknownTarget => write!(f, "The given target could not be found. Run `rustup target list` for an overview of available toolchains."),
             CargoMSRVError::UnableToCacheChannelManifest => write!(f, "Unable to get or store the channel manifest on disk."),
-            CargoMSRVError::UnableToFindAnyGoodVersion => write!(f, "{}", NO_GOOD_VERSION_FOUND),
+            CargoMSRVError::UnableToFindAnyGoodVersion { latest_toolchain } => write!(f, r#"Unable to find a Minimum Supported Rust Version (MSRV).
+
+If you think this result is erroneous, please run: `rustup run {} cargo build --all` manually.
+
+If the above does succeed, or you think cargo-msrv errored in another way, please feel free to
+report the issue at: https://github.com/foresterre/cargo-msrv/issues
+
+Thank you in advance!"#, latest_toolchain.as_str()),
             CargoMSRVError::UnableToParseCliArgs => write!(f, "Unable to parse the CLI arguments. Use `cargo msrv help` for more info."),
             CargoMSRVError::UnableToParseRustVersion => write!(f, "The Rust stable version could not be parsed from the stable channel manifest."),
             CargoMSRVError::UnableToRunCheck => write!(f, "Unable to run the checking command. If --check <cmd> is specified, you could try to verify if you can run the cmd manually." )

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -98,7 +98,7 @@ pub fn default_target() -> TResult<String> {
     })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct RustStableVersion {
     major: u16,
     minor: u16,
@@ -149,6 +149,16 @@ impl RustStableVersion {
 
     pub fn as_string(&self) -> String {
         format!("{}.{}.{}", self.major, self.minor, self.patch)
+    }
+
+    pub fn as_toolchain_string<T: AsRef<str>>(&self, target: T) -> String {
+        format!(
+            "{}.{}.{}-{}",
+            self.major,
+            self.minor,
+            self.patch,
+            target.as_ref()
+        )
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,10 @@ pub fn run_cargo_msrv() -> TResult<()> {
             Ok(())
         }
         MinimalCompatibility::None { latest_toolchain } => {
-            Err(CargoMSRVError::UnableToFindAnyGoodVersion { latest_toolchain })
+            Err(CargoMSRVError::UnableToFindAnyGoodVersion {
+                latest_toolchain,
+                command: config.check_command().join(" "),
+            })
         }
     }
 }

--- a/tests/with_versions.rs
+++ b/tests/with_versions.rs
@@ -38,7 +38,8 @@ fn check_all_feature_versions<I: IntoIterator<Item = T>, T: Into<OsString> + Clo
             let matches = cargo_msrv::cli::cmd_matches(&matches).unwrap();
             println!("matches: {:?}", &matches);
 
-            let result = cargo_msrv::msrv(&matches, RustStableVersion::new(1, 38, 0)).unwrap();
+            let result =
+                cargo_msrv::determine_msrv(&matches, RustStableVersion::new(1, 38, 0)).unwrap();
             println!("result: {:?}", &result);
 
             let expected = project_dir.clone();
@@ -47,7 +48,7 @@ fn check_all_feature_versions<I: IntoIterator<Item = T>, T: Into<OsString> + Clo
             let expected =
                 RustStableVersion::from_parts(&expected.split('.').collect::<Vec<_>>()).unwrap();
 
-            assert_eq!(result.unwrap(), expected);
+            assert_eq!(result.unwrap_version(), expected);
         }
     }
 }


### PR DESCRIPTION
Previously the program would report to run a manual check with "the current version". This commit pre-fills the command which you can run manually, so it is copy-paste-able.