### PR TITLE
Default to check --all instead of build --all

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ impl<'a> CmdMatches<'a> {
     pub fn new(target: String) -> Self {
         Self {
             target,
-            check_command: vec!["cargo", "build", "--all"],
+            check_command: vec!["cargo", "check", "--all"],
             seek_path: None,
             include_all_patch_releases: false,
             minimum_version: None,


### PR DESCRIPTION
The extra linting step performed by 'cargo build' is, to the best of my knowledge, not necessary to check whether a crate is compatible with a certain Rust release.

closes #59