### PR TITLE
Refine bisect UI and status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,8 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "rust-releases"
-version = "0.13.0"
-source = "git+https://github.com/foresterre/rust-releases.git?branch=main#598f3528065da9da77cf13ba5e919e25b4ea5ac4"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c11bc407220e9131ffac096710ffbdec700a3bd9f2e968caeba1337d62fe96"
 dependencies = [
  "attohttpc",
  "directories-next",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/foresterre/cargo-msrv"
 clap = "2.33.0"
 
 # Get the available rust versions
-rust-releases = { git = "https://github.com/foresterre/rust-releases.git", branch = "main" }
+rust-releases = "0.14.0"
 
 # UI
 console = "0.14.1"

--- a/src/check.rs
+++ b/src/check.rs
@@ -81,7 +81,7 @@ fn try_building(
     if !status.success() {
         ui.complete_step(
             format!(
-                "{} red light for {}",
+                "{} Bad check for {}",
                 style("Done").green().bold(),
                 style(version).cyan()
             )
@@ -95,7 +95,7 @@ fn try_building(
     } else {
         ui.complete_step(
             format!(
-                "{} green light for {}",
+                "{} Good check for {}",
                 style("Done").green().bold(),
                 style(version).cyan()
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub fn determine_msrv(
 
     // Pre-filter the [min-version:max-version] range
     let included_releases = releases
-        .iter()
+        .into_iter()
         .filter(|release| {
             include_version(
                 release.version(),
@@ -104,24 +104,14 @@ pub fn determine_msrv(
                 config.maximum_version(),
             )
         })
-        .copied()
+        .cloned()
         .collect::<Vec<_>>();
 
     // Whether to perform a linear (most recent to least recent), or binary search
     if config.bisect() {
-        // FIXME: work around - incompatible types in rust-releases 0.13 for bisect and linear search
-        let included_releases = included_releases
-            .iter()
-            .map(|e| Release::new(e.version().clone()))
-            .collect::<Vec<_>>();
         test_against_releases_bisect(&included_releases, &mut compatibility, config, &ui)?;
     } else {
-        test_against_releases_linearly(
-            included_releases.as_ref(),
-            &mut compatibility,
-            config,
-            &ui,
-        )?;
+        test_against_releases_linearly(&included_releases, &mut compatibility, config, &ui)?;
     }
 
     match &compatibility {
@@ -137,8 +127,8 @@ pub fn determine_msrv(
     Ok(compatibility)
 }
 
-fn test_against_releases_linearly<'release>(
-    releases: &[&'release Release],
+fn test_against_releases_linearly(
+    releases: &[Release],
     compatibility: &mut MinimalCompatibility,
     config: &CmdMatches,
     ui: &Printer,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -51,16 +51,8 @@ impl Printer {
         );
     }
 
-    pub fn skip_version(&self, version: &semver::Version) {
-        self.progress.set_message(
-            format!(
-                "{} {}",
-                style("Skipping").green().bold(),
-                style(version).cyan()
-            )
-            .as_str(),
-        );
-        self.progress.inc(1);
+    pub fn set_progress_bar_length(&self, len: u64) {
+        self.progress.set_length(len)
     }
 
     pub fn finish_with_ok(&self, version: &semver::Version) {

--- a/tests/with_versions.rs
+++ b/tests/with_versions.rs
@@ -24,6 +24,18 @@ fn validate_feature_versions_with_custom_cmd() {
     check_all_feature_versions(f)
 }
 
+#[test]
+fn validate_feature_versions_with_bisect() {
+    fn f(path: PathBuf) -> impl IntoIterator<Item = String> {
+        let path_args = with_path(path).into_iter();
+        let custom_check_args = vec!["--bisect".to_string()];
+
+        path_args.chain(custom_check_args)
+    }
+
+    check_all_feature_versions(f)
+}
+
 fn check_all_feature_versions<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(
     args: impl Fn(PathBuf) -> I,
 ) {


### PR DESCRIPTION
* Update rust-releases dependency to 0.14
* Clean up bisect and linear search inputs
* Updates status text from green and red light to good and bad check
* Refine UI for bisect by reducing the length to the progressed + remaining possible versions
* Add integration tests for bisect