### PR TITLE
DO NOT MERGE: Add debugging info for the CI runner

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -1,4 +1,4 @@
-use crate::command::command;
+use crate::command::{command, command_with_output};
 use crate::config::CmdMatches;
 use crate::errors::{CargoMSRVError, TResult};
 use crate::ui::Printer;
@@ -51,10 +51,19 @@ fn download_if_required(
     let toolchain = toolchain_specifier.to_owned();
     ui.show_progress("Installing", version);
 
-    let status = command(&["install", "--profile", "minimal", &toolchain], None)
-        .and_then(|mut c| c.wait().map_err(CargoMSRVError::Io))?;
+    let status = command_with_output(&["install", "--profile", "minimal", &toolchain])
+        .and_then(|c| c.wait_with_output().map_err(CargoMSRVError::Io))?;
 
-    if !status.success() {
+    let out = String::from_utf8_lossy(&status.stdout);
+    let err = String::from_utf8_lossy(&status.stderr);
+
+    println!("----");
+    dbg!(out);
+    dbg!(err);
+    println!("----");
+    println!("----");
+
+    if !status.status.success() {
         return Err(CargoMSRVError::RustupInstallFailed(
             toolchain_specifier.to_string(),
         ));


### PR DESCRIPTION
#69 and #70 fail on a flaky (unreproducable so far) process where toolchain version can not be installed.

When running locally, by first removing installed toolchains and then letting `cargo-msrv` install the required toolchains for the integration tests worked once to reproduce the issue, but I wasn't able to locate the source of the failure.

After that one reproduction, I wasn't able to reproduce the issue locally anymore. On the CI the issue still occurs however.

Possibilities:
* a regression in the latest rustup?
  * `1.24.{0, 1}`
  * https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#1240---2021-04-27 
  * (only observed Windows failures thus far)
* ...?
