### PR TITLE
Added `Output` trait and JSON status printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "clap",
  "console",
  "indicatif",
+ "json",
  "parameterized",
  "rust-releases",
  "yare",
@@ -267,6 +268,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ clap = "2.33.0"
 console = "0.14.1"
 indicatif = "0.16.1"
 
+# json output
+json = "0.12.4"
+
 # Get the available rust versions
 [dependencies.rust-releases]
 version = "0.15.3"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ OPTIONS:
         --minimum <min>
             Earliest version to take into account.
 
+        --output-format <output_format>
+            Output status messages in machine-readable format. Machine-readable status updates will be printed in the
+            requested format to stdout. [possible values: json]
         --path <DIR>
             Path to the cargo project directory
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,65 @@ rustup, i.e. validation commands will be passed to rustup like so: `rustup run <
 need to provide the <COMMAND...> part.
 ```
 
+### JSON format
+
+There are 4 types of status messages, each type is indicated
+by the `reason` key.
+
+#### Installing and Checking
+
+```jsonc
+{
+  "reason": "installing", /* OR */ "reason": "checking",
+  // The current version being installed or checked
+  "version": "1.25.0",
+  // The number of versions checked before this
+  "step": 0,
+  // The total number of versions to be checked
+  "total": 55,
+  // The toolchain that is being used
+  "toolchain": "x86_64-unknown-linux-gnu",
+  // The command used to check each version
+  "check_cmd": "cargo check --all"
+}
+```
+
+#### Check complete
+
+```jsonc
+{
+  "reason": "check-complete",
+  // The version that was just checked
+  "version": "1.25.0",
+  // The number of versions checked before this
+  "step": 0,
+  // The total number of versions to be checked
+  "total": 55,
+  // true if this version is supported
+  "success": false,
+  // The toolchain that is being used
+  "toolchain": "x86_64-unknown-linux-gnu",
+  // The command used to check each version
+  "check_cmd": "cargo check --all"
+}
+```
+
+#### MSRV complete
+
+```jsonc
+{
+  "reason": "msrv-complete",
+  // true if a msrv was found
+  "success": true,
+  // the msrv if found. The key will be absent if msrv wasn't found
+  "msrv": "1.42.0",
+  // The toolchain that is being used
+  "toolchain": "x86_64-unknown-linux-gnu",
+  // The command used to check each version
+  "check_cmd": "cargo check --all"
+}
+```
+
 ### Testing
 
 Tests should be run with a single thread, because otherwise `rustup` uses the a single place for the download cache of a

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,7 @@ pub mod id {
     pub const ARG_BISECT: &str = "bisect";
     pub const ARG_TOOLCHAIN_FILE: &str = "toolchain_file";
     pub const ARG_IGNORE_LOCKFILE: &str = "lockfile";
+    pub const ARG_OUTPUT_FORMAT: &str = "output_format";
 }
 
 pub fn cli() -> App<'static, 'static> {
@@ -101,6 +102,13 @@ so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provide the <COMM
                     .long_help("Temporarily removes the lockfile, so it will not interfere with the building process. \
                     This is important when testing against Rust versions prior to 1.38.0, for which Cargo does not recognize the new v2 lockfile.")
                 )
+                .arg(Arg::with_name(id::ARG_OUTPUT_FORMAT)
+                    .long("output-format")
+                    .help("Output status messages in machine-readable format")
+                    .takes_value(true)
+                    .possible_values(&["json"])
+                    .long_help("Output status messages in machine-readable format. \
+                Machine-readable status updates will be printed in the requested format to stdout."))
                 .arg(
                     Arg::with_name(id::ARG_CUSTOM_CHECK)
                         .value_name("COMMAND")

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::errors::CargoMSRVError;
+use crate::errors::{CargoMSRVError, TResult};
 use clap::ArgMatches;
 use rust_releases::semver;
 use std::convert::TryFrom;
@@ -6,8 +6,21 @@ use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy)]
 pub enum OutputFormat {
+    /// Progress bar rendered to stderr
     Human,
+    /// Json status updates printed to stdout
     Json,
+    /// No output -- meant to be used for testing
+    None,
+}
+
+/// Gets a [`Config`] from the given matches, but sets output_format to None
+///
+/// This is meant to be used for testing
+pub fn test_config_from_matches<'a>(matches: &'a ArgMatches<'a>) -> TResult<Config<'a>> {
+    let mut config = Config::try_from(matches)?;
+    config.output_format = OutputFormat::None;
+    Ok(config)
 }
 
 #[derive(Debug, Clone)]

--- a/src/json.rs
+++ b/src/json.rs
@@ -40,7 +40,7 @@ impl crate::Output for JsonPrinter<'_> {
                 step: self.finished.get(),
                 total: self.steps.get(),
                 toolchain: self.toolchain,
-                chech_cmd: self.cmd,
+                check_cmd: self.cmd,
             }
         );
     }
@@ -55,7 +55,7 @@ impl crate::Output for JsonPrinter<'_> {
                 total_steps: self.steps.get(),
                 success: success,
                 toolchain: self.toolchain,
-                chech_cmd: self.cmd,
+                check_cmd: self.cmd,
             }
         );
         self.finished.set(self.finished.get() + 1);
@@ -69,7 +69,7 @@ impl crate::Output for JsonPrinter<'_> {
                 success: true,
                 msrv: version.to_string(),
                 toolchain: self.toolchain,
-                chech_cmd: self.cmd,
+                check_cmd: self.cmd,
             }
         )
     }
@@ -81,7 +81,7 @@ impl crate::Output for JsonPrinter<'_> {
                 reason: "msrv-complete",
                 success: false,
                 toolchain: self.toolchain,
-                chech_cmd: self.cmd,
+                check_cmd: self.cmd,
             }
         );
     }

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,88 @@
+use json::object;
+use std::cell::Cell;
+
+use rust_releases::semver;
+
+pub struct JsonPrinter<'a> {
+    finished: Cell<u64>,
+    steps: Cell<u64>,
+    toolchain: &'a str,
+    cmd: &'a str,
+}
+
+impl<'a> JsonPrinter<'a> {
+    pub fn new(steps: u64, toolchain: &'a str, cmd: &'a str) -> Self {
+        Self {
+            finished: Cell::new(0),
+            steps: Cell::new(steps),
+            toolchain,
+            cmd,
+        }
+    }
+}
+
+impl crate::Output for JsonPrinter<'_> {
+    fn set_steps(&self, steps: u64) {
+        self.steps.set(steps);
+    }
+
+    fn progress(&self, action: crate::ProgressAction, version: &semver::Version) {
+        let action = match action {
+            crate::ProgressAction::Installing => "installing",
+            crate::ProgressAction::Checking => "checking",
+        };
+
+        println!(
+            "{}",
+            object! {
+                reason: action,
+                version: version.to_string(),
+                step: self.finished.get(),
+                total: self.steps.get(),
+                toolchain: self.toolchain,
+                chech_cmd: self.cmd,
+            }
+        );
+    }
+
+    fn complete_step(&self, version: &semver::Version, success: bool) {
+        println!(
+            "{}",
+            object! {
+                reason: "check-complete",
+                version: version.to_string(),
+                step: self.finished.get(),
+                total_steps: self.steps.get(),
+                success: success,
+                toolchain: self.toolchain,
+                chech_cmd: self.cmd,
+            }
+        );
+        self.finished.set(self.finished.get() + 1);
+    }
+
+    fn finish_success(&self, version: &semver::Version) {
+        println!(
+            "{}",
+            object! {
+                reason: "msrv-complete",
+                success: true,
+                msrv: version.to_string(),
+                toolchain: self.toolchain,
+                chech_cmd: self.cmd,
+            }
+        )
+    }
+
+    fn finish_failure(&self, _: &str) {
+        println!(
+            "{}",
+            object! {
+                reason: "msrv-complete",
+                success: false,
+                toolchain: self.toolchain,
+                chech_cmd: self.cmd,
+            }
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,16 @@ pub trait Output {
     fn finish_failure(&self, cmd: &str);
 }
 
+/// This is meant to be used for testing
+struct NoOutput;
+impl Output for NoOutput {
+    fn set_steps(&self, _steps: u64) {}
+    fn progress(&self, _action: ProgressAction, _version: &semver::Version) {}
+    fn complete_step(&self, _version: &semver::Version, _success: bool) {}
+    fn finish_success(&self, _version: &semver::Version) {}
+    fn finish_failure(&self, _cmd: &str) {}
+}
+
 pub fn determine_msrv(
     config: &Config,
     index: &rust_releases::ReleaseIndex,
@@ -131,6 +141,10 @@ pub fn determine_msrv(
         config::OutputFormat::Json => {
             let output =
                 json::JsonPrinter::new(included_releases.len() as u64, config.target(), &cmd);
+            determine_msrv_impl(config, &included_releases, &cmd, &output)
+        }
+        config::OutputFormat::None => {
+            let output = NoOutput;
             determine_msrv_impl(config, &included_releases, &cmd, &output)
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,12 +3,12 @@ use indicatif::{ProgressBar, ProgressStyle};
 use rust_releases::semver;
 use std::borrow::Cow;
 
-pub struct Printer {
+pub struct HumanPrinter {
     term: Term,
     progress: ProgressBar,
 }
 
-impl Printer {
+impl HumanPrinter {
     pub fn new(steps: u64) -> Self {
         let term = Term::stderr();
 
@@ -77,5 +77,44 @@ impl Printer {
             )
             .as_str(),
         );
+    }
+}
+
+impl crate::Output for HumanPrinter {
+    fn set_steps(&self, steps: u64) {
+        self.set_progress_bar_length(steps);
+    }
+
+    fn progress(&self, action: crate::ProgressAction, version: &semver::Version) {
+        let action = match action {
+            crate::ProgressAction::Installing => "Installing",
+            crate::ProgressAction::Checking => "Checking",
+        };
+
+        self.show_progress(action, version);
+    }
+
+    fn complete_step(&self, version: &semver::Version, success: bool) {
+        if success {
+            self.complete_step(format!(
+                "{} Good check for {}",
+                style("Done").green().bold(),
+                style(version).cyan()
+            ));
+        } else {
+            self.complete_step(format!(
+                "{} Bad check for {}",
+                style("Done").green().bold(),
+                style(version).cyan()
+            ));
+        }
+    }
+
+    fn finish_success(&self, version: &semver::Version) {
+        self.finish_with_ok(version)
+    }
+
+    fn finish_failure(&self, cmd: &str) {
+        self.finish_with_err(cmd)
     }
 }

--- a/tests/with_versions.rs
+++ b/tests/with_versions.rs
@@ -1,10 +1,9 @@
 extern crate cargo_msrv;
 
-use cargo_msrv::config::Config;
+use cargo_msrv::config::test_config_from_matches;
 use cargo_msrv::MinimalCompatibility;
 use parameterized::parameterized;
 use rust_releases::{semver, Release, ReleaseIndex};
-use std::convert::TryFrom;
 use std::ffi::OsString;
 use std::iter::FromIterator;
 
@@ -110,7 +109,7 @@ fn msrv_with_custom_command(folder: &str, expected_version: semver::Version) {
 
 fn run<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(with_args: I) -> MinimalCompatibility {
     let matches = cargo_msrv::cli::cli().get_matches_from(with_args);
-    let matches = Config::try_from(&matches).expect("Unable to parse cli arguments");
+    let matches = test_config_from_matches(&matches).expect("Unable to parse cli arguments");
 
     // Limit the available versions: this ensures we don't need to incrementally install more toolchains
     //  as more Rust toolchains become available.
@@ -150,7 +149,7 @@ fn run_cargo_version_which_doesnt_support_lockfile_v2<
     with_args: I,
 ) -> MinimalCompatibility {
     let matches = cargo_msrv::cli::cli().get_matches_from(with_args);
-    let matches = Config::try_from(&matches).expect("Unable to parse cli arguments");
+    let matches = test_config_from_matches(&matches).expect("Unable to parse cli arguments");
 
     // Limit the available versions: this ensures we don't want to incrementally install more toolchains
     //  as more Rust toolchains become available.


### PR DESCRIPTION
This PR adds the `--output-format` option, which for now only supports `json`.

Since the methods are now generic over anything that implements the `Output` trait, I also added a `NoOutput` struct so that during tests, nothing is printed.