### PR TITLE
Add implementation to verify the MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "console",
+ "decent-toml-rs-alternative",
  "indicatif",
  "json",
  "parameterized",
@@ -137,6 +138,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "decent-serde-toml-derive-alternative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53488745da0d2cfd08c7ffd9cc264ee15c2d2ea1aa3ce6f1ad77220ce4d3677e"
+dependencies = [
+ "decent-synquote-alternative",
+ "proc-macro2",
+]
+
+[[package]]
+name = "decent-synquote-alternative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb30bb3e9d6bf9de3577b38bc4aa8dd31d74afeaa10653f720f43347f3d443a"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "decent-toml-rs-alternative"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112ee4bc8f1c942282027a43e46b068d40350c5f20ab9131a3d02626706be7ed"
+dependencies = [
+ "decent-serde-toml-derive-alternative",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0/MIT"
 edition = "2018"
 repository = "https://github.com/foresterre/cargo-msrv"
 
+[package.metadata]
+msrv = "1.42.0"
+
 [dependencies]
 # Used for parsing cli arguments.
 clap = "2.33.0"
@@ -17,6 +20,9 @@ indicatif = "0.16.2"
 
 # json output
 json = "0.12.4"
+
+# read Cargo.toml
+decent-toml-rs-alternative = "0.3.0"
 
 # Get the available rust versions
 [dependencies.rust-releases]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ With Cargo from Github [latest development version]:
 * `cargo msrv --path <dir>` to find the MSRV in the `<dir>` directory cargo project.
 * `cargo msrv -- <command> ` to use `<command>` as the compatibility check which decides whether a Rust version is
 compatible or not. This command should be runnable through `rustup run <toolchain> <command>`.
+* `cargo msrv --verify`  to verify the MSRV, if defined with the 'package.metadata.msrv' key in the 'Cargo.toml'.
 
 **Options:**
 ```
@@ -67,6 +68,10 @@ OPTIONS:
     -V, --version
             Prints version information
 
+        --verify
+            Verify the MSRV, if defined with the 'package.metadata.msrv' key in the 'Cargo.toml'. When this flag is
+            present, cargo-msrv will not attempt to determine the true MSRV. It will only attempt to verify specified
+            MSRV, the Rust build passes similarly to regular cargo-msrv runs. 
 
 ARGS:
     <COMMAND>...
@@ -82,10 +87,30 @@ need to provide the <COMMAND...> part.
 
 ### JSON format
 
-There are 4 types of status messages, each type is indicated
+There are 6 types of status messages, each type is indicated
 by the `reason` key.
 
+#### Report mode
+
+Reports the mode which will be used by `cargo-msrv`. There are currently two modes:
+`determine-msrv` and `verify-msrv`, which respectively 
+
+```jsonc
+{
+  "reason": "mode",
+  // The mode in which cargo-msrv will operate
+  "mode": "determine-msrv" /* OR */ "action": "verify-msrv",
+    // The toolchain that will be used
+  "toolchain":"x86_64-unknown-linux-gnu",
+  // command used to check a version 
+  "check_cmd":"cargo check --all"}
+}
+```
+
 #### Installing and Checking
+
+Reported when a toolchain will be installed, or when a toolchain will
+be run to check whether the version of the toolchain is compatible.
 
 ```jsonc
 {
@@ -105,6 +130,9 @@ by the `reason` key.
 
 #### Check complete
 
+Reported when a check, which determines whether the toolchain version under test
+is compatible, completes.
+
 ```jsonc
 {
   "reason": "check-complete",
@@ -123,11 +151,13 @@ by the `reason` key.
 }
 ```
 
-#### MSRV complete
+#### MSRV completed
+
+Reported when all actions for a mode have been run to completion. 
 
 ```jsonc
 {
-  "reason": "msrv-complete",
+  "reason": "msrv-complete" /* OR */ "reason": "verify-complete",
   // true if a msrv was found
   "success": true,
   // the msrv if found. The key will be absent if msrv wasn't found

--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -1,7 +1,17 @@
-use cargo_msrv::run_cargo_msrv;
+use cargo_msrv::config::Config;
+use cargo_msrv::errors::TResult;
+use cargo_msrv::{cli, run_app};
+use std::convert::TryFrom;
 
 fn main() {
-    if let Err(err) = run_cargo_msrv() {
+    if let Err(err) = init_and_run() {
         eprintln!("{}", err);
     }
+}
+
+fn init_and_run() -> TResult<()> {
+    let matches = cli::cli().get_matches();
+    let config = Config::try_from(&matches)?;
+
+    run_app(&config)
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,8 +1,9 @@
 use crate::command::command;
 use crate::config::Config;
+use crate::crate_root_folder;
 use crate::errors::{CargoMSRVError, TResult};
 use crate::lockfile::{LockfileHandler, CARGO_LOCK};
-use crate::{crate_root_folder, Output, ProgressAction};
+use crate::reporter::{Output, ProgressAction};
 use rust_releases::semver;
 use std::path::Path;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,6 +13,7 @@ pub mod id {
     pub const ARG_TOOLCHAIN_FILE: &str = "toolchain_file";
     pub const ARG_IGNORE_LOCKFILE: &str = "lockfile";
     pub const ARG_OUTPUT_FORMAT: &str = "output_format";
+    pub const ARG_VERIFY: &str = "verify_msrv";
 }
 
 pub fn cli() -> App<'static, 'static> {
@@ -108,7 +109,16 @@ so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provide the <COMM
                     .takes_value(true)
                     .possible_values(&["json"])
                     .long_help("Output status messages in machine-readable format. \
-                Machine-readable status updates will be printed in the requested format to stdout."))
+                Machine-readable status updates will be printed in the requested format to stdout.")
+                )
+                .arg(Arg::with_name(id::ARG_VERIFY)
+                    .long("verify")
+                    .help("Verify the MSRV, if defined with the 'package.metadata.msrv' key in the Cargo.toml")
+                    .long_help("Verify the MSRV, if defined with the 'package.metadata.msrv' key in the 'Cargo.toml'. \
+                    When this flag is present, cargo-msrv will not attempt to determine the true MSRV. \
+                    It will only attempt to verify specified MSRV, the Rust build passes similarly to regular cargo-msrv runs. ")
+                    .takes_value(false)
+                )
                 .arg(
                     Arg::with_name(id::ARG_CUSTOM_CHECK)
                         .value_name("COMMAND")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ fn run_verify_msrv_action(config: &Config, _release_index: &ReleaseIndex) -> TRe
         .and_then(|field| field.get("metadata"))
         .and_then(|field| field.get("msrv"))
         .and_then(|value| value.as_string())
-        .ok_or_else(|| CargoMSRVError::NoMSRVKeyInCargoToml(cargo_toml))?;
+        .ok_or(CargoMSRVError::NoMSRVKeyInCargoToml(cargo_toml))?;
 
     let version = semver::Version::parse(&msrv).map_err(CargoMSRVError::SemverError)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,14 @@
 #![allow(clippy::upper_case_acronyms, clippy::unnecessary_wraps)]
 
 use crate::check::{as_toolchain_specifier, check_toolchain, CheckStatus};
-use crate::config::Config;
+use crate::config::{Config, ModeIntent};
 use crate::errors::{CargoMSRVError, TResult};
+use crate::reporter::{json, ui};
+use crate::reporter::{Output, ProgressAction, __private::NoOutput};
 use rust_releases::linear::LatestStableReleases;
-use rust_releases::{semver, Channel, FetchResources, Release, RustChangelog, Source};
-use std::convert::TryFrom;
+use rust_releases::{
+    semver, Channel, FetchResources, Release, ReleaseIndex, RustChangelog, Source,
+};
 use std::path::PathBuf;
 
 pub mod check;
@@ -15,18 +18,21 @@ pub mod command;
 pub mod config;
 pub mod errors;
 pub mod fetch;
-pub mod json;
 pub mod lockfile;
-pub mod ui;
+pub mod reporter;
 
-pub fn run_cargo_msrv() -> TResult<()> {
-    let matches = cli::cli().get_matches();
-    let config = Config::try_from(&matches)?;
-
+pub fn run_app(config: &Config) -> TResult<()> {
     let index_strategy = RustChangelog::fetch_channel(Channel::Stable)?;
     let index = index_strategy.build_index()?;
 
-    match determine_msrv(&config, &index)? {
+    match config.action_intent() {
+        ModeIntent::DetermineMSRV => run_determine_msrv_action(config, &index),
+        ModeIntent::VerifyMSRV => run_verify_msrv_action(config, &index),
+    }
+}
+
+fn run_determine_msrv_action(config: &Config, release_index: &ReleaseIndex) -> TResult<()> {
+    match determine_msrv(config, release_index)? {
         MinimalCompatibility::NoCompatibleToolchains => {
             Err(CargoMSRVError::UnableToFindAnyGoodVersion {
                 command: config.check_command().join(" "),
@@ -38,6 +44,58 @@ pub fn run_cargo_msrv() -> TResult<()> {
             output_toolchain_file(&config, version)
         }
         MinimalCompatibility::CapableToolchain { .. } => Ok(()),
+    }
+}
+
+fn run_verify_msrv_action(config: &Config, _release_index: &ReleaseIndex) -> TResult<()> {
+    let crate_folder = crate_root_folder(config)?;
+    let cargo_toml = crate_folder.join("Cargo.toml");
+
+    let contents = std::fs::read_to_string(&cargo_toml).map_err(CargoMSRVError::Io)?;
+    let document =
+        decent_toml_rs_alternative::parse_toml(&contents).map_err(CargoMSRVError::ParseToml)?;
+
+    let msrv = document
+        .get("package")
+        .and_then(|field| field.get("metadata"))
+        .and_then(|field| field.get("msrv"))
+        .and_then(|value| value.as_string())
+        .ok_or_else(|| CargoMSRVError::NoMSRVKeyInCargoToml(cargo_toml))?;
+
+    let version = semver::Version::parse(&msrv).map_err(CargoMSRVError::SemverError)?;
+
+    let cmd = config.check_command().join(" ");
+
+    match config.output_format() {
+        config::OutputFormat::Human => {
+            let reporter = ui::HumanPrinter::new(1, config.target(), &cmd);
+            reporter.mode(ModeIntent::VerifyMSRV);
+            let status = check_toolchain(&version, config, &reporter)?;
+            report_verify_completion(&reporter, status, &cmd);
+        }
+        config::OutputFormat::Json => {
+            let reporter = json::JsonPrinter::new(1, config.target(), &cmd);
+            reporter.mode(ModeIntent::VerifyMSRV);
+            let status = check_toolchain(&version, config, &reporter)?;
+            report_verify_completion(&reporter, status, &cmd);
+        }
+        config::OutputFormat::None => {
+            let reporter = NoOutput;
+            reporter.mode(ModeIntent::VerifyMSRV);
+            let status = check_toolchain(&version, config, &reporter)?;
+            report_verify_completion(&reporter, status, &cmd);
+        }
+    };
+
+    Ok(())
+}
+
+fn report_verify_completion(output: &impl Output, status: CheckStatus, cmd: &str) {
+    match status {
+        CheckStatus::Success { version, .. } => {
+            output.finish_success(ModeIntent::VerifyMSRV, &version)
+        }
+        CheckStatus::Failure { .. } => output.finish_failure(ModeIntent::VerifyMSRV, cmd),
     }
 }
 
@@ -78,30 +136,6 @@ impl From<CheckStatus> for MinimalCompatibility {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ProgressAction {
-    Installing,
-    Checking,
-}
-
-pub trait Output {
-    fn set_steps(&self, steps: u64);
-    fn progress(&self, action: ProgressAction, version: &semver::Version);
-    fn complete_step(&self, version: &semver::Version, success: bool);
-    fn finish_success(&self, version: &semver::Version);
-    fn finish_failure(&self, cmd: &str);
-}
-
-/// This is meant to be used for testing
-struct NoOutput;
-impl Output for NoOutput {
-    fn set_steps(&self, _steps: u64) {}
-    fn progress(&self, _action: ProgressAction, _version: &semver::Version) {}
-    fn complete_step(&self, _version: &semver::Version, _success: bool) {}
-    fn finish_success(&self, _version: &semver::Version) {}
-    fn finish_failure(&self, _cmd: &str) {}
-}
-
 pub fn determine_msrv(
     config: &Config,
     index: &rust_releases::ReleaseIndex,
@@ -134,17 +168,19 @@ pub fn determine_msrv(
 
     match config.output_format() {
         config::OutputFormat::Human => {
-            let ui = ui::HumanPrinter::new(included_releases.len() as u64);
-            ui.welcome(config.target(), &cmd);
+            let ui = ui::HumanPrinter::new(included_releases.len() as u64, config.target(), &cmd);
+            ui.mode(ModeIntent::DetermineMSRV);
             determine_msrv_impl(config, &included_releases, &cmd, &ui)
         }
         config::OutputFormat::Json => {
             let output =
                 json::JsonPrinter::new(included_releases.len() as u64, config.target(), &cmd);
+            output.mode(ModeIntent::DetermineMSRV);
             determine_msrv_impl(config, &included_releases, &cmd, &output)
         }
         config::OutputFormat::None => {
             let output = NoOutput;
+            output.mode(ModeIntent::DetermineMSRV);
             determine_msrv_impl(config, &included_releases, &cmd, &output)
         }
     }
@@ -172,9 +208,11 @@ fn determine_msrv_impl(
             toolchain: _,
             version,
         } => {
-            output.finish_success(&version);
+            output.finish_success(ModeIntent::DetermineMSRV, &version);
         }
-        MinimalCompatibility::NoCompatibleToolchains => output.finish_failure(cmd),
+        MinimalCompatibility::NoCompatibleToolchains => {
+            output.finish_failure(ModeIntent::DetermineMSRV, cmd)
+        }
     }
 
     Ok(compatibility)

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1,0 +1,43 @@
+use crate::config::ModeIntent;
+use rust_releases::semver;
+
+pub mod json;
+pub mod ui;
+
+#[derive(Debug, Clone, Copy)]
+pub enum ProgressAction {
+    Installing,
+    Checking,
+}
+
+pub trait Output {
+    // Shows the mode in which cargo-msrv will operate
+    fn mode(&self, mode: ModeIntent);
+
+    // Sets the remaining amount of steps for the mode
+    fn set_steps(&self, steps: u64);
+
+    // Reports the currently running
+    fn progress(&self, action: ProgressAction, version: &semver::Version);
+    fn complete_step(&self, version: &semver::Version, success: bool);
+    fn finish_success(&self, mode: ModeIntent, version: &semver::Version);
+    fn finish_failure(&self, mode: ModeIntent, cmd: &str);
+}
+
+pub mod __private {
+    use crate::config::ModeIntent;
+    use crate::reporter::{Output, ProgressAction};
+    use rust_releases::semver;
+
+    /// This is meant to be used for testing
+    pub struct NoOutput;
+
+    impl Output for NoOutput {
+        fn mode(&self, _action: ModeIntent) {}
+        fn set_steps(&self, _steps: u64) {}
+        fn progress(&self, _action: ProgressAction, _version: &semver::Version) {}
+        fn complete_step(&self, _version: &semver::Version, _success: bool) {}
+        fn finish_success(&self, _mode: ModeIntent, _version: &semver::Version) {}
+        fn finish_failure(&self, _mode: ModeIntent, _cmd: &str) {}
+    }
+}


### PR DESCRIPTION
* Allows verifying a certain MSRV without installing other toolchains
* Not yet implemented: option to directly run cargo-msrv in determine-msrv mode when the verification check failed
* Requires MSRV to be defined in the Cargo.toml, specifically in the `package.metadata.msrv` key.