### PR TITLE
Show why a build failed using a cause

### DIFF
--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -1,6 +1,7 @@
 use json::object;
 use std::cell::Cell;
 
+use crate::check::Cause;
 use crate::config::ModeIntent;
 use crate::reporter::ProgressAction;
 use rust_releases::semver;
@@ -98,7 +99,7 @@ impl crate::Output for JsonPrinter<'_> {
         )
     }
 
-    fn finish_failure(&self, mode: ModeIntent, _: &str) {
+    fn finish_failure(&self, mode: ModeIntent, _: &str, _cause: Option<&Cause>) {
         let reason = self.complete_reason(mode);
 
         println!(

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1,3 +1,4 @@
+use crate::check::Cause;
 use crate::config::ModeIntent;
 use rust_releases::semver;
 
@@ -21,10 +22,11 @@ pub trait Output {
     fn progress(&self, action: ProgressAction, version: &semver::Version);
     fn complete_step(&self, version: &semver::Version, success: bool);
     fn finish_success(&self, mode: ModeIntent, version: &semver::Version);
-    fn finish_failure(&self, mode: ModeIntent, cmd: &str);
+    fn finish_failure(&self, mode: ModeIntent, cmd: &str, cause: Option<&Cause>);
 }
 
 pub mod __private {
+    use crate::check::Cause;
     use crate::config::ModeIntent;
     use crate::reporter::{Output, ProgressAction};
     use rust_releases::semver;
@@ -38,6 +40,6 @@ pub mod __private {
         fn progress(&self, _action: ProgressAction, _version: &semver::Version) {}
         fn complete_step(&self, _version: &semver::Version, _success: bool) {}
         fn finish_success(&self, _mode: ModeIntent, _version: &semver::Version) {}
-        fn finish_failure(&self, _mode: ModeIntent, _cmd: &str) {}
+        fn finish_failure(&self, _mode: ModeIntent, _cmd: &str, _cause: Option<&Cause>) {}
     }
 }

--- a/src/reporter/ui.rs
+++ b/src/reporter/ui.rs
@@ -1,3 +1,4 @@
+use crate::check::Cause;
 use crate::config::ModeIntent;
 use console::{style, Term};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -137,7 +138,7 @@ impl<'config> crate::Output for HumanPrinter<'config> {
         }
     }
 
-    fn finish_failure(&self, _mode: ModeIntent, cmd: &str) {
+    fn finish_failure(&self, _mode: ModeIntent, cmd: &str, _cause: Option<&Cause>) {
         self.finish_with_err(cmd)
     }
 }

--- a/tests/with_versions.rs
+++ b/tests/with_versions.rs
@@ -69,7 +69,7 @@ fn msrv_unsupported() {
     let with_args = vec!["cargo", "msrv", "--path", folder.to_str().unwrap()];
 
     let result = run(with_args);
-    assert_eq!(result, MinimalCompatibility::NoCompatibleToolchains);
+    assert!(result.is_no_compatible_toolchains());
 }
 
 #[parameterized(


### PR DESCRIPTION
Currently, only supported for "HumanPrinter"

WIP, see:

```
 // TODO also for bisect version, this is wrong since we determine compatibility by finding the
            //  n+1'th version which still works. If we instead set the nth, non-compatible version, as
            //  minimally compatible, we will always return a failure
            // *compatibility = MinimalCompatibility::NoCompatibleToolchains { cause };
```