### PR TITLE
Update dependency rust-releases to v0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +381,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,15 +470,6 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
 
 [[package]]
 name = "pkg-config"
@@ -563,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "rust-releases"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29faccc649813028822852d823b9ea0372b42d5b10f862dc0aae3d4ca43532b9"
+checksum = "9c906d779820772a372d5a8c8c5549315fcd96e6c62226c51fa806f6fe69fafa"
 dependencies = [
  "rust-releases-core",
  "rust-releases-rust-changelog",
@@ -573,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "rust-releases-core"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7189f044eb0556daf823e51f0f147731aaf2259196540976541e4d7eaeffc0f8"
+checksum = "79730c017cb81c23618f95865cb75395105ea88a70cc606b7306853207f5337a"
 dependencies = [
  "semver",
  "thiserror",
@@ -583,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "rust-releases-io"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c090def79df80c8ec89027e33dbcd0a05e1e30e1bbfe75a12a35f5b4e577c71e"
+checksum = "8485a7f6a6d39e97a74e392dcd03176800cccbe7b0e8c44b60331a5b5c00b7e6"
 dependencies = [
  "attohttpc",
  "directories-next",
@@ -594,10 +617,11 @@ dependencies = [
 
 [[package]]
 name = "rust-releases-rust-changelog"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa72b4c93b329aad9a3c35bfd90635954bc5e802f2e8f2dd4bf13f6aebd26d1e"
+checksum = "a97c7b03eb34e7aa7dc28d0ad9ba9608497563d907e12f08dd3170e78151597b"
 dependencies = [
+ "chrono",
  "rust-releases-core",
  "rust-releases-io",
  "thiserror",
@@ -638,21 +662,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "strsim"
@@ -725,6 +737,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,12 +761,6 @@ name = "tinyvec_macros"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
@@ -801,9 +818,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wildmatch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ decent-toml-rs-alternative = "0.3.0"
 
 # Get the available rust versions
 [dependencies.rust-releases]
-version = "0.15.4"
+version = "0.16.0"
 default-features = false
 features = ["rust-releases-rust-changelog"]
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,7 +22,7 @@ pub enum CargoMSRVError {
     RustReleasesSource(rust_releases::RustChangelogError),
     RustupInstallFailed(ToolchainSpecifier),
     RustupRunWithCommandFailed,
-    SemverError(rust_releases::semver::SemVerError),
+    SemverError(rust_releases::semver::Error),
     SystemTime(std::time::SystemTimeError),
     ToolchainNotInstalled,
     UnknownTarget,
@@ -105,8 +105,8 @@ impl From<decent_toml_rs_alternative::TomlError> for CargoMSRVError {
     }
 }
 
-impl From<rust_releases::semver::SemVerError> for CargoMSRVError {
-    fn from(err: rust_releases::semver::SemVerError) -> Self {
+impl From<rust_releases::semver::Error> for CargoMSRVError {
+    fn from(err: rust_releases::semver::Error) -> Self {
         CargoMSRVError::SemverError(err)
     }
 }


### PR DESCRIPTION
This version most prominently includes a fix for the rust-changelog variant (we depend on), which will no longer will include unreleased versions in preparation in the release list when using the rust changelog source.