### PR TITLE
sketch alternative CLI using declarative syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "attohttpc"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,17 +93,33 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.0.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "fcd70aa5597dbc42f7217a543f9ef2768b2ef823ba29036072d30e1d88e98406"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5bb0d655624a0b8770d1c178fb8ffcb1f91cc722cb08f451e3dc72465421ac"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -265,6 +272,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +315,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -445,6 +477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6acbef58a60fe69ab50510a55bc8cdd4d6cf2283d27ad338f54cb52747a9cf2d"
+
+[[package]]
 name = "parameterized"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,10 +522,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.24"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -668,15 +730,15 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.62"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123a78a3596b24fee53a6464ce52d8ecbf62241e6294c7e7fe12086cd161f512"
+checksum = "5239bc68e0fef57495900cfea4e8dc75596d9a319d7e16b1e0a440d24e6fe0a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -698,6 +760,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "unicode-width",
 ]
@@ -781,6 +852,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +894,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +926,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ msrv = "1.42.0"
 
 [dependencies]
 # Used for parsing cli arguments.
-clap = "2.33.0"
+clap = "=3.0.0-beta.4"
 
 # UI
 console = "0.14.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,139 +1,103 @@
-use crate::fetch::is_target_available;
-use clap::{App, AppSettings, Arg, SubCommand};
+use std::path::{Path, PathBuf};
 
-pub mod id {
-    pub const SUB_COMMAND_MSRV: &str = "msrv";
-    pub const ARG_SEEK_PATH: &str = "seek_path";
-    pub const ARG_SEEK_CUSTOM_TARGET: &str = "seek_target";
-    pub const ARG_CUSTOM_CHECK: &str = "custom_check";
-    pub const ARG_INCLUDE_ALL_PATCH_RELEASES: &str = "include_all_patch";
-    pub const ARG_MIN: &str = "min";
-    pub const ARG_MAX: &str = "max";
-    pub const ARG_BISECT: &str = "bisect";
-    pub const ARG_TOOLCHAIN_FILE: &str = "toolchain_file";
-    pub const ARG_IGNORE_LOCKFILE: &str = "lockfile";
-    pub const ARG_OUTPUT_FORMAT: &str = "output_format";
-    pub const ARG_VERIFY: &str = "verify_msrv";
+use crate::{errors::TResult, fetch::is_target_available};
+use clap::Clap;
+use rust_releases::semver::Version;
+
+#[derive(Clap)]
+pub struct Config {
+    /// Path to the cargo project directory
+    #[clap(long = "path", validator = "path_exists_validator", value_name = "DIR")]
+    seek_path: Option<PathBuf>,
+
+    /// Check against a custom target (instead of the rustup default)
+    #[clap(
+        long = "target",
+        validator = "seek_target_validator",
+        value_name = "TARGET"
+    )]
+    seek_target: Option<String>,
+
+    /// Include all patch releases, instead of only the last
+    #[clap(long)]
+    include_all_patch_releases: bool,
+
+    /// Earliest version to take into account
+    ///
+    /// Version must match a valid Rust toolchain, and be semver compatible.
+    #[clap(long, alias = "minimum")]
+    min: Option<Version>,
+
+    /// Latest version to take into account
+    ///
+    /// Version must match a valid Rust toolchain, and be semver compatible.
+    #[clap(long, alias = "maximum")]
+    max: Option<Version>,
+
+    /// Use a binary search to find the MSRV instead of a linear search
+    #[clap(long)]
+    bisect: bool,
+
+    /// Output a rust-toolchain file with the MSRV as toolchain
+    ///
+    /// The toolchain file will pin the Rust version for this crate.
+    /// See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file for more.
+    #[clap(long)]
+    toolchain_file: bool,
+
+    /// Temporarily removes the lockfile, so it will not interfere with the building process
+    ///
+    /// This is important when testing against Rust versions prior to 1.38.0, for which Cargo does not recognize the new v2 lockfile.
+    #[clap(long)]
+    ignore_lockfile: bool,
+
+    /// Output status messages in machine-readable format
+    ///
+    /// Machine-readable status updates will be printed in the requested format to stdout.
+    #[clap(long, default_value = "human")]
+    output_format: OutputFormat,
+
+    /// Verify the MSRV, if defined with the 'package.metadata.msrv' key in the Cargo.toml
+    ///
+    /// When this flag is present, cargo-msrv will not attempt to determine the true MSRV.
+    /// It will only attempt to verify specified MSRV, the Rust build passes similarly to regular cargo-msrv runs.
+    #[clap(long)]
+    verify: bool,
+
+    /// If given, this command is used to validate if a Rust version is
+    /// compatible. Should be available to rustup, i.e. the command should work like
+    /// so: `rustup run <toolchain> <COMMAND>`.
+    /// The default check action is `cargo check --all`.
+    #[clap(setting(clap::ArgSettings::Last))]
+    custom_command: Vec<String>,
 }
 
-pub fn cli() -> App<'static, 'static> {
-    App::new("cargo-msrv")
-        .bin_name("cargo")
-        .version(env!("CARGO_PKG_VERSION"))
-        .author("Martijn Gribnau <garm@ilumeo.com>")
-        .global_setting(AppSettings::NextLineHelp)
-        .global_setting(AppSettings::ColoredHelp)
-        .global_setting(AppSettings::ColorAuto)
-        .global_setting(AppSettings::DontCollapseArgsInUsage)
-        .global_setting(AppSettings::UnifiedHelpMessage)
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .max_term_width(120)
-        .subcommand(
-            SubCommand::with_name(id::SUB_COMMAND_MSRV)
-                .usage("cargo msrv [OPTIONS]")
-                .about("Helps with finding the Minimal Supported Rust Version (MSRV)")
-                .after_help("\
-If arguments are provided after two dashes (`--`), they will be used as a custom command to validate \
-whether a Rust version is compatible. By default for this validation the command `cargo build` is \
-used. Commands should be runnable by rustup, i.e. validation commands will be passed to rustup like \
-so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provide the <COMMAND...> part.")
-                .arg(
-                    Arg::with_name(id::ARG_SEEK_PATH)
-                        .long("path")
-                        .help("Path to the cargo project directory")
-                        .takes_value(true)
-                        .value_name("DIR")
-                        .validator(|value| {
-                            std::fs::metadata(&value)
-                                .map_err(|_| "Path doesn't exist.".to_string())
-                                .and_then(|m| {
-                                    if m.is_dir() {
-                                        Ok(())
-                                    } else {
-                                        Err("Not a directory.".to_string())
-                                    }
-                                })
-                        }),
-                )
-                .arg(
-                    Arg::with_name(id::ARG_SEEK_CUSTOM_TARGET)
-                        .long("target")
-                        .help("Check against a custom target (instead of the rustup default)")
-                        .takes_value(true)
-                        .value_name("TARGET")
-                        .validator(|value| {
-                            is_target_available(&value).map_err(|_| {
-                                "The provided target is not available. Use `rustup target list` to \
-                                 review the available targets."
-                                    .to_string()
-                            })
-                        }),
-                )
-                .arg(Arg::with_name(id::ARG_INCLUDE_ALL_PATCH_RELEASES)
-                    .long("include-all-patch-releases")
-                    .help("Include all patch releases, instead of only the last")
-                    .takes_value(false)
-                )
-                .arg(Arg::with_name(id::ARG_MIN)
-                    .long("min")
-                    .visible_alias("minimum")
-                    .help("Earliest version to take into account")
-                    .long_help("Earliest (least recent) version to take into account. \
-                     Version must match a valid Rust toolchain, and be semver compatible.")
-                    .takes_value(true)
-                )
-                .arg(Arg::with_name(id::ARG_MAX)
-                    .long("max")
-                    .visible_alias("maximum")
-                    .help("Latest version to take into account")
-                    .long_help("Latest (most recent) version to take into account.\
-                     Version must match a valid Rust toolchain, and be semver compatible.")
-                    .takes_value(true)
-                )
-                .arg(Arg::with_name(id::ARG_BISECT)
-                    .long("bisect")
-                    .help("Use a binary search to find the MSRV instead of a linear search")
-                    .takes_value(false)
-                )
-                .arg(Arg::with_name(id::ARG_TOOLCHAIN_FILE)
-                    .long("toolchain-file")
-                    .help("Output a rust-toolchain file with the MSRV as toolchain")
-                    .long_help("Output a rust-toolchain file with the MSRV as toolchain. \
-                    The toolchain file will pin the Rust version for this crate. \
-                    See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file for more.")
-                )
-                .arg(Arg::with_name(id::ARG_IGNORE_LOCKFILE)
-                    .long("ignore-lockfile")
-                    .help("Temporarily removes the lockfile, so it will not interfere with the building process")
-                    .long_help("Temporarily removes the lockfile, so it will not interfere with the building process. \
-                    This is important when testing against Rust versions prior to 1.38.0, for which Cargo does not recognize the new v2 lockfile.")
-                )
-                .arg(Arg::with_name(id::ARG_OUTPUT_FORMAT)
-                    .long("output-format")
-                    .help("Output status messages in machine-readable format")
-                    .takes_value(true)
-                    .possible_values(&["json"])
-                    .long_help("Output status messages in machine-readable format. \
-                Machine-readable status updates will be printed in the requested format to stdout.")
-                )
-                .arg(Arg::with_name(id::ARG_VERIFY)
-                    .long("verify")
-                    .help("Verify the MSRV, if defined with the 'package.metadata.msrv' key in the Cargo.toml")
-                    .long_help("Verify the MSRV, if defined with the 'package.metadata.msrv' key in the 'Cargo.toml'. \
-                    When this flag is present, cargo-msrv will not attempt to determine the true MSRV. \
-                    It will only attempt to verify specified MSRV, the Rust build passes similarly to regular cargo-msrv runs. ")
-                    .takes_value(false)
-                )
-                .arg(
-                    Arg::with_name(id::ARG_CUSTOM_CHECK)
-                        .value_name("COMMAND")
-                        .help("If given, this command is used to validate if a Rust version is \
-                        compatible. Should be available to rustup, i.e. the command should work like \
-                        so: `rustup run <toolchain> <COMMAND>`. \
-                        The default check action is `cargo check --all`.")
-                        .multiple(true)
-                        .last(true)
+fn path_exists_validator(path: &Path) -> Result<(), String> {
+    std::fs::metadata(path)
+        .map_err(|_| "Path doesn't exist.".to_string())
+        .and_then(|m| {
+            if m.is_dir() {
+                Ok(())
+            } else {
+                Err("Not a directory.".to_string())
+            }
+        })
+}
 
-                )
-        )
+fn seek_target_validator(target: &str) -> TResult<()> {
+    is_target_available(target).map_err(|_| {
+        "The provided target is not available. Use `rustup target list` to \
+             review the available targets."
+            .to_string()
+    })
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum OutputFormat {
+    /// Progress bar rendered to stderr
+    Human,
+    /// Json status updates printed to stdout
+    Json,
+    /// No output -- meant to be used for testing
+    None,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,15 +4,7 @@ use rust_releases::semver;
 use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Copy)]
-pub enum OutputFormat {
-    /// Progress bar rendered to stderr
-    Human,
-    /// Json status updates printed to stdout
-    Json,
-    /// No output -- meant to be used for testing
-    None,
-}
+
 
 /// Gets a [`Config`] from the given matches, but sets output_format to None
 ///
@@ -154,13 +146,13 @@ impl<'a> ConfigBuilder<'a> {
         self
     }
 
-    pub fn minimum_version(mut self, version: Option<semver::Version>) -> Self {
-        self.inner.minimum_version = version;
+    pub fn minimum_version(mut self, version: semver::Version) -> Self {
+        self.inner.minimum_version = Some(version);
         self
     }
 
-    pub fn maximum_version(mut self, version: Option<semver::Version>) -> Self {
-        self.inner.maximum_version = version;
+    pub fn maximum_version(mut self, version: semver::Version) -> Self {
+        self.inner.maximum_version = Some(version);
         self
     }
 
@@ -228,11 +220,11 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
         }
 
         if let Some(min) = arg_matches.value_of(id::ARG_MIN) {
-            builder = builder.minimum_version(Some(rust_releases::semver::Version::parse(min)?))
+            builder = builder.minimum_version(parse_version(min)?)
         }
 
         if let Some(max) = arg_matches.value_of(id::ARG_MAX) {
-            builder = builder.maximum_version(Some(rust_releases::semver::Version::parse(max)?))
+            builder = builder.maximum_version(rust_releases::semver::Version::parse(max)?)
         }
 
         builder = builder.bisect(arg_matches.is_present(id::ARG_BISECT));
@@ -255,5 +247,36 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
         }
 
         Ok(builder.build())
+    }
+}
+
+fn parse_version(input: &str) -> Result<semver::Version, semver::Error> {
+    match input {
+        "2018" => Ok(semver::Version::new(1, 31, 0)),
+        "2021" => Ok(semver::Version::new(1, 56, 0)),
+        s => semver::Version::parse(s),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use parameterized::parameterized;
+    use rust_releases::semver::Version;
+
+    #[parameterized(
+        input = {
+            "1.35.0",
+            "2018",
+            "2021",
+        },
+        expected_version = {
+            Version::new(1,35,0),
+            Version::new(1,31,0),
+            Version::new(1,56,0),
+        }
+    )]
+    fn parse_version(input: &str, expected_version: Version) {
+        let version = super::super::parse_version(input).unwrap();
+        assert_eq!(version, expected_version)
     }
 }


### PR DESCRIPTION
Closes #107 

this is incomplete, but meant to illustrate what the CLI implementation could look like using declarative syntax. this would replace the existing `cli` and `config` modules with a single struct.

i've accidentally stacked this on #104, but you get the idea