### PR TITLE
Release 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [0.10.0] - 2021-10-01
+
+* Add option to specify an edition alias instead of a minimum version
+
 # [0.9.0] - 2021-09-06
 
 * cargo-msrv will no longer try to install upcoming, but unreleased, Rust releases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cargo-msrv"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-msrv"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 description = "Find your minimum supported Rust version (MSRV)!"
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
Very small release which adds the option to provide an edition alias instead of a minimum version. The alias points to the first version which includes the edition (on the stable channel)