### PR TITLE
Refactor: add a dynamic reporter and make it available to the whole program

### DIFF
--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -1,5 +1,6 @@
 use cargo_msrv::config::Config;
 use cargo_msrv::errors::TResult;
+use cargo_msrv::reporter::ReporterBuilder;
 use cargo_msrv::{cli, run_app};
 use std::convert::TryFrom;
 
@@ -13,5 +14,11 @@ fn init_and_run() -> TResult<()> {
     let matches = cli::cli().get_matches();
     let config = Config::try_from(&matches)?;
 
-    run_app(&config)
+    let target = config.target().as_str();
+    let cmd = config.check_command_string();
+    let reporter = ReporterBuilder::new(target, cmd.as_str())
+        .output_format(config.output_format())
+        .build();
+
+    run_app(&config, &reporter)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,12 @@ pub enum OutputFormat {
     None,
 }
 
+impl Default for OutputFormat {
+    fn default() -> Self {
+        Self::Human
+    }
+}
+
 /// Gets a [`Config`] from the given matches, but sets output_format to None
 ///
 /// This is meant to be used for testing
@@ -102,6 +108,10 @@ impl<'a> Config<'a> {
 
     pub fn check_command(&self) -> &Vec<&'a str> {
         &self.check_command
+    }
+
+    pub fn check_command_string(&self) -> String {
+        self.check_command.join(" ")
     }
 
     pub fn crate_path(&self) -> Option<&Path> {

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -5,15 +5,15 @@ use crate::config::ModeIntent;
 use crate::reporter::ProgressAction;
 use rust_releases::semver;
 
-pub struct JsonPrinter<'a> {
+pub struct JsonPrinter<'s, 't> {
     finished: Cell<u64>,
     steps: Cell<u64>,
-    toolchain: &'a str,
-    cmd: &'a str,
+    toolchain: &'s str,
+    cmd: &'t str,
 }
 
-impl<'a> JsonPrinter<'a> {
-    pub fn new(steps: u64, toolchain: &'a str, cmd: &'a str) -> Self {
+impl<'s, 't> JsonPrinter<'s, 't> {
+    pub fn new(steps: u64, toolchain: &'s str, cmd: &'t str) -> Self {
         Self {
             finished: Cell::new(0),
             steps: Cell::new(steps),
@@ -30,9 +30,10 @@ impl<'a> JsonPrinter<'a> {
     }
 }
 
-impl crate::Output for JsonPrinter<'_> {
+impl<'s, 't> crate::Output for JsonPrinter<'s, 't> {
     fn mode(&self, mode: ModeIntent) {
         let mode: &str = mode.into();
+
         println!(
             "{}",
             object! {

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1,5 +1,7 @@
+use crate::config;
 use crate::config::ModeIntent;
 use rust_releases::semver;
+use rust_releases::semver::Version;
 
 pub mod json;
 pub mod ui;
@@ -22,6 +24,77 @@ pub trait Output {
     fn complete_step(&self, version: &semver::Version, success: bool);
     fn finish_success(&self, mode: ModeIntent, version: &semver::Version);
     fn finish_failure(&self, mode: ModeIntent, cmd: &str);
+}
+
+pub struct Reporter<'output> {
+    output: Box<dyn Output + 'output>,
+}
+
+impl<'output> Reporter<'output> {
+    fn new(output: Box<dyn Output + 'output>) -> Self {
+        Self { output }
+    }
+}
+
+impl<'output> Output for Reporter<'output> {
+    fn mode(&self, mode: ModeIntent) {
+        self.output.mode(mode)
+    }
+
+    fn set_steps(&self, steps: u64) {
+        self.output.set_steps(steps)
+    }
+
+    fn progress(&self, action: ProgressAction, version: &Version) {
+        self.output.progress(action, version)
+    }
+
+    fn complete_step(&self, version: &Version, success: bool) {
+        self.output.complete_step(version, success)
+    }
+
+    fn finish_success(&self, mode: ModeIntent, version: &Version) {
+        self.output.finish_success(mode, version)
+    }
+
+    fn finish_failure(&self, mode: ModeIntent, cmd: &str) {
+        self.output.finish_failure(mode, cmd)
+    }
+}
+
+pub struct ReporterBuilder<'s> {
+    target: &'s str,
+    cmd: &'s str,
+    output_format: config::OutputFormat,
+}
+
+impl<'s> ReporterBuilder<'s> {
+    pub fn new(target: &'s str, cmd: &'s str) -> Self {
+        Self {
+            target,
+            cmd,
+            output_format: Default::default(),
+        }
+    }
+
+    pub fn output_format(mut self, output_format: config::OutputFormat) -> Self {
+        self.output_format = output_format;
+        self
+    }
+
+    pub fn build(self) -> Reporter<'s> {
+        let boxed: Box<dyn Output> = match self.output_format {
+            config::OutputFormat::Human => {
+                Box::new(ui::HumanPrinter::new(1, self.target, self.cmd))
+            }
+            config::OutputFormat::Json => {
+                Box::new(json::JsonPrinter::new(1, self.target, self.cmd))
+            }
+            config::OutputFormat::None => Box::new(__private::NoOutput),
+        };
+
+        Reporter::new(boxed)
+    }
 }
 
 pub mod __private {

--- a/src/reporter/ui.rs
+++ b/src/reporter/ui.rs
@@ -4,15 +4,15 @@ use indicatif::{ProgressBar, ProgressStyle};
 use rust_releases::semver;
 use std::borrow::Cow;
 
-pub struct HumanPrinter<'config> {
+pub struct HumanPrinter<'s, 't> {
     term: Term,
     progress: ProgressBar,
-    toolchain: &'config str,
-    cmd: &'config str,
+    toolchain: &'s str,
+    cmd: &'t str,
 }
 
-impl<'config> HumanPrinter<'config> {
-    pub fn new(steps: u64, toolchain: &'config str, cmd: &'config str) -> Self {
+impl<'s, 't> HumanPrinter<'s, 't> {
+    pub fn new(steps: u64, toolchain: &'s str, cmd: &'t str) -> Self {
         let term = Term::stderr();
 
         let progress = ProgressBar::new(steps).with_style(
@@ -96,7 +96,7 @@ impl<'config> HumanPrinter<'config> {
     }
 }
 
-impl<'config> crate::Output for HumanPrinter<'config> {
+impl<'s, 't> crate::Output for HumanPrinter<'s, 't> {
     fn mode(&self, action: ModeIntent) {
         self.welcome(self.toolchain, self.cmd, action);
     }


### PR DESCRIPTION
Previously outputs were created only after the index was initialized, and was constructed for each output separately.

This commit adds a reporter which internalizes the output logic. The reporter is constructed just after parsing the configuration, and as such can be used through the whole program, including indexing.