### PR TITLE
Log message when fetching index

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -96,7 +96,7 @@ fn download_if_required(
     output: &impl Output,
 ) -> TResult<()> {
     let toolchain = toolchain_specifier.to_owned();
-    output.progress(ProgressAction::Installing, version);
+    output.progress(ProgressAction::Installing(version));
 
     let status = command(&["install", "--profile", "minimal", &toolchain], None)
         .and_then(|mut c| c.wait().map_err(CargoMSRVError::Io))?;
@@ -131,7 +131,7 @@ fn try_building(
     cmd.extend_from_slice(check);
 
     let mut child = command(&cmd, dir).map_err(|_| CargoMSRVError::UnableToRunCheck)?;
-    output.progress(ProgressAction::Checking, version);
+    output.progress(ProgressAction::Checking(version));
 
     let status = child.wait()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod lockfile;
 pub mod reporter;
 
 pub fn run_app(config: &Config, reporter: &Reporter) -> TResult<()> {
+    reporter.progress(ProgressAction::FetchingIndex);
+
     let index = match config.release_source() {
         ReleaseSource::RustChangelog => {
             RustChangelog::fetch_channel(Channel::Stable)?.build_index()?
@@ -204,7 +206,7 @@ fn test_against_releases_linearly(
     output: &impl Output,
 ) -> TResult<()> {
     for release in releases {
-        output.progress(ProgressAction::Checking, release.version());
+        output.progress(ProgressAction::Checking(release.version()));
         let outcome = check_toolchain(release.version(), config, output)?;
 
         if !outcome.is_success() {
@@ -230,7 +232,7 @@ fn test_against_releases_bisect(
     let progressed = std::cell::Cell::new(0u64);
     let mut binary_search = Bisect::from_slice(releases);
     let outcome = binary_search.search_with_result_and_remainder(|release, remainder| {
-        output.progress(ProgressAction::Checking, release.version());
+        output.progress(ProgressAction::Checking(release.version()));
 
         // increment progressed items
         let steps = progressed.replace(progressed.get().saturating_add(1));

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -49,23 +49,33 @@ impl<'s, 't> crate::Output for JsonPrinter<'s, 't> {
         self.steps.set(steps);
     }
 
-    fn progress(&self, action: crate::ProgressAction, version: &semver::Version) {
-        let action = match action {
-            ProgressAction::Installing => "installing",
-            ProgressAction::Checking => "checking",
+    fn progress(&self, action: crate::ProgressAction) {
+        let action_str = match action {
+            ProgressAction::Installing(_) => "installing",
+            ProgressAction::Checking(_) => "checking",
+            ProgressAction::FetchingIndex => "fetching-index",
         };
 
-        println!(
-            "{}",
-            object! {
-                reason: action,
-                version: version.to_string(),
-                step: self.finished.get(),
-                total: self.steps.get(),
-                toolchain: self.toolchain,
-                check_cmd: self.cmd,
-            }
-        );
+        match action {
+            ProgressAction::Installing(version) | ProgressAction::Checking(version) => println!(
+                "{}",
+                object! {
+                    reason: action_str,
+                    version: version.to_string(),
+                    step: self.finished.get(),
+                    total: self.steps.get(),
+                    toolchain: self.toolchain,
+                    check_cmd: self.cmd,
+                }
+            ),
+            ProgressAction::FetchingIndex => println!(
+                "{}",
+                object! {
+                    reason: action_str,
+                    check_cmd: self.cmd
+                }
+            ),
+        };
     }
 
     fn complete_step(&self, version: &semver::Version, success: bool) {

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -7,9 +7,10 @@ pub mod json;
 pub mod ui;
 
 #[derive(Debug, Clone, Copy)]
-pub enum ProgressAction {
-    Installing,
-    Checking,
+pub enum ProgressAction<'a> {
+    Installing(&'a semver::Version),
+    Checking(&'a semver::Version),
+    FetchingIndex,
 }
 
 pub trait Output {
@@ -20,7 +21,7 @@ pub trait Output {
     fn set_steps(&self, steps: u64);
 
     // Reports the currently running
-    fn progress(&self, action: ProgressAction, version: &semver::Version);
+    fn progress(&self, action: ProgressAction);
     fn complete_step(&self, version: &semver::Version, success: bool);
     fn finish_success(&self, mode: ModeIntent, version: &semver::Version);
     fn finish_failure(&self, mode: ModeIntent, cmd: &str);
@@ -45,8 +46,8 @@ impl<'output> Output for Reporter<'output> {
         self.output.set_steps(steps)
     }
 
-    fn progress(&self, action: ProgressAction, version: &Version) {
-        self.output.progress(action, version)
+    fn progress(&self, action: ProgressAction) {
+        self.output.progress(action)
     }
 
     fn complete_step(&self, version: &Version, success: bool) {
@@ -108,7 +109,7 @@ pub mod __private {
     impl Output for NoOutput {
         fn mode(&self, _action: ModeIntent) {}
         fn set_steps(&self, _steps: u64) {}
-        fn progress(&self, _action: ProgressAction, _version: &semver::Version) {}
+        fn progress(&self, _action: ProgressAction) {}
         fn complete_step(&self, _version: &semver::Version, _success: bool) {}
         fn finish_success(&self, _mode: ModeIntent, _version: &semver::Version) {}
         fn finish_failure(&self, _mode: ModeIntent, _cmd: &str) {}

--- a/src/reporter/ui.rs
+++ b/src/reporter/ui.rs
@@ -105,13 +105,18 @@ impl<'s, 't> crate::Output for HumanPrinter<'s, 't> {
         self.set_progress_bar_length(steps);
     }
 
-    fn progress(&self, action: crate::ProgressAction, version: &semver::Version) {
-        let action = match action {
-            crate::ProgressAction::Installing => "Installing",
-            crate::ProgressAction::Checking => "Checking",
+    fn progress(&self, action: crate::ProgressAction) {
+        let (action, version) = match action {
+            crate::ProgressAction::Installing(version) => ("Installing", Some(version)),
+            crate::ProgressAction::Checking(version) => ("Checking", Some(version)),
+            crate::ProgressAction::FetchingIndex => ("Fetching index", None),
         };
 
-        self.show_progress(action, version);
+        if let Some(version) = version {
+            self.show_progress(action, version);
+        } else {
+            let _ = self.term.write_line(action);
+        }
     }
 
     fn complete_step(&self, version: &semver::Version, success: bool) {


### PR DESCRIPTION
Closes #120. Modifies the existing `progress` method here to make the version optional and adds `ProgressAction::FetchingIndex` enum variant.

This seemed like the most logical place to put the fetching index message, but I think it might also make sense to add a new method like `display_message` that's more flexible and doesn't rely on the `ProgressAction` enum for showing one off logs like this. Happy to take a look into that if it's a better fit