### PR TITLE
Let codecov behave as an informational entity only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
Currently we're trying out codecov and whether we like it or not. cargo-msrv does have a need to work on its testing situation, in particular by having a cleaner testing structure, and allowing more code to be unit-testable. Codecov may positively impact this by helping us figure out which parts of the code base are most dire in need of testing and refactoring.

We're however still figuring out how coverage works with cargo-tarpoulin and codecov and have seen huge (as far as we can see incorrect) diffs for very small patches. Such diffs result in failing merge status' and impact speed of development more than is fun for a project we develop in our free time.

As such we've decided to keep codecov, but set it to purely informational.