### PR TITLE
RUSTSEC-2020-0071 and RUSTSEC-2020-0159: Potential segfault in localtime_r invocations

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,5 +15,13 @@ vulnerability = "deny"
 unmaintained = "deny"
 notice = "deny"
 ignore = [
+    # stdweb is unmaintained
     "RUSTSEC-2020-0056",
+
+    # Potential segfault in the time crate
+    # NB: has been fixed in time >=0.2.23, however waiting on chrono crate to update
+    # chrono PR: https://github.com/chronotope/chrono/pull/578
+    "RUSTSEC-2020-0071",
+    # Potential segfault in localtime_r invocations, see 0071
+    "RUSTSEC-2020-0159",
 ]


### PR DESCRIPTION
Time crate has been updated, but we depend on chrono and are waiting for it to update. The PR is open but the maintainer seems unresponsive. For now, we'll wait a bit as it's actually very unlikely for the segfault to take place, and, the impact on cargo-msrv is not significant.
In time, we may want to replace chrono, assuming it's unmaintained.

ref https://github.com/chronotope/chrono/pull/578