### PR TITLE
Improve option to run standalone

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,7 @@
 use crate::fetch::is_target_available;
-use clap::{App, AppSettings, Arg, SubCommand};
+use clap::{App, AppSettings, Arg};
 
 pub mod id {
-    pub const SUB_COMMAND_MSRV: &str = "msrv";
     pub const ARG_SEEK_PATH: &str = "seek_path";
     pub const ARG_SEEK_CUSTOM_TARGET: &str = "seek_target";
     pub const ARG_CUSTOM_CHECK: &str = "custom_check";
@@ -21,7 +20,6 @@ pub mod id {
 
 pub fn cli() -> App<'static, 'static> {
     App::new("cargo-msrv")
-        .bin_name("cargo")
         .version(env!("CARGO_PKG_VERSION"))
         .author("Martijn Gribnau <garm@ilumeo.com>")
         .global_setting(AppSettings::NextLineHelp)
@@ -29,134 +27,129 @@ pub fn cli() -> App<'static, 'static> {
         .global_setting(AppSettings::ColorAuto)
         .global_setting(AppSettings::DontCollapseArgsInUsage)
         .global_setting(AppSettings::UnifiedHelpMessage)
-        .setting(AppSettings::SubcommandRequiredElseHelp)
         .max_term_width(120)
-        .subcommand(
-            SubCommand::with_name(id::SUB_COMMAND_MSRV)
-                .version(env!("CARGO_PKG_VERSION"))
-                .usage("cargo msrv [OPTIONS]")
-                .about("Helps with finding the Minimal Supported Rust Version (MSRV)")
-                .after_help("\
+        .usage("cargo msrv [OPTIONS] or cargo-msrv [OPTIONS]")
+        .about("Helps with finding the Minimal Supported Rust Version (MSRV)")
+        .after_help("\
 An argument provided after two dashes (`--`), will be interpreted as a custom command `check` command, \
 used to validate whether a Rust toolchain version is compatible. The default `check` command is \
 \"cargo build\". A custom `check` command should be runnable by rustup, as they will be passed on to \
 rustup like so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provide the <COMMAND...> part.")
-                .arg(
-                    Arg::with_name(id::ARG_SEEK_PATH)
-                        .long("path")
-                        .help("Path to the cargo project directory")
-                        .takes_value(true)
-                        .value_name("DIR")
-                        .validator(|value| {
-                            std::fs::metadata(&value)
-                                .map_err(|_| "Path doesn't exist.".to_string())
-                                .and_then(|m| {
-                                    if m.is_dir() {
-                                        Ok(())
-                                    } else {
-                                        Err("Not a directory.".to_string())
-                                    }
-                                })
-                        }),
-                )
-                .arg(
-                    Arg::with_name(id::ARG_SEEK_CUSTOM_TARGET)
-                        .long("target")
-                        .help("Check against a custom target (instead of the rustup default)")
-                        .takes_value(true)
-                        .value_name("TARGET")
-                        .validator(|value| {
-                            is_target_available(&value).map_err(|_| {
-                                "The provided target is not available. Use `rustup target list` to \
-                                 review the available targets."
-                                    .to_string()
-                            })
-                        }),
-                )
-                .arg(Arg::with_name(id::ARG_INCLUDE_ALL_PATCH_RELEASES)
-                    .long("include-all-patch-releases")
-                    .help("Include all patch releases, instead of only the last")
-                    .takes_value(false)
-                )
-                .arg(Arg::with_name(id::ARG_MIN)
-                    .long("min")
-                    .visible_alias("minimum")
-                    .help("Earliest version to take into account")
-                    .long_help("Earliest (least recent) version to take into account. \
-                     Version must match a valid Rust toolchain, and be semver compatible. Edition aliases may also be used.")
-                    .takes_value(true)
-                )
-                .arg(Arg::with_name(id::ARG_MAX)
-                    .long("max")
-                    .visible_alias("maximum")
-                    .help("Latest version to take into account")
-                    .long_help("Latest (most recent) version to take into account.\
-                     Version must match a valid Rust toolchain, and be semver compatible.")
-                    .takes_value(true)
-                )
-                .arg(Arg::with_name(id::ARG_BISECT)
-                    .long("bisect")
-                    .help("Use a binary search to find the MSRV instead of a linear search")
-                    .takes_value(false)
-                )
-                .arg(Arg::with_name(id::ARG_TOOLCHAIN_FILE)
-                    .long("toolchain-file")
-                    .help("Output a rust-toolchain file with the MSRV as toolchain")
-                    .long_help("Output a rust-toolchain file with the MSRV as toolchain. \
-                    The toolchain file will pin the Rust version for this crate. \
-                    See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file for more.")
-                )
-                .arg(Arg::with_name(id::ARG_IGNORE_LOCKFILE)
-                    .long("ignore-lockfile")
-                    .help("Temporarily removes the lockfile, so it will not interfere with the building process")
-                    .long_help("Temporarily removes the lockfile, so it will not interfere with the building process. \
-                    This is important when testing against Rust versions prior to 1.38.0, for which Cargo does not recognize the new v2 lockfile.")
-                )
-                .arg(Arg::with_name(id::ARG_OUTPUT_FORMAT)
-                    .long("output-format")
-                    .help("Output status messages in machine-readable format")
-                    .takes_value(true)
-                    .possible_values(&["json"])
-                    .long_help("Output status messages in machine-readable format. \
-                Machine-readable status updates will be printed in the requested format to stdout.")
-                )
-                .arg(Arg::with_name(id::ARG_VERIFY)
-                    .long("verify")
-                    .help("Verify the MSRV defined in the 'package.rust-version' or the 'package.metadata.msrv' key in Cargo.toml")
-                    .long_help("Verify the MSRV defined in the 'package.rust-version' or the 'package.metadata.msrv' key in Cargo.toml. \
-                    When this flag is present, cargo-msrv will not attempt to determine the true MSRV. \
-                    Instead it attempts to verify whether for the specified MSRV, the `check` command passes. This is similar to \
-                    how we determine whether a Rust toolchain version is compatible for your crate or not.")
-                    .takes_value(false)
-                )
-                .arg(Arg::with_name(id::ARG_RELEASE_SOURCE)
-                    .long("release-source")
-                    .help("Select the rust-releases source to use as the release index")
-                    .takes_value(true)
-                    .possible_values(&["rust-changelog", "rust-dist"])
-                    .default_value("rust-changelog")
-                )
-                .arg(Arg::with_name(id::ARG_NO_LOG)
-                    .long("no-log")
-                    .help("Disable logging")
-                    .takes_value(false)
-                )
-                .arg(Arg::with_name(id::ARG_NO_READ_MIN_EDITION)
-                    .long("no-read-min-edition")
-                    .help("If provided, the 'package.edition' value in the Cargo.toml will not \
-                    be used to reduce search space.")
-                    .takes_value(false)
-                )
-                .arg(
-                    Arg::with_name(id::ARG_CUSTOM_CHECK)
-                        .value_name("COMMAND")
-                        .help("If given, this command is used to validate if a Rust version is \
-                        compatible. Should be available to rustup, i.e. the command should work like \
-                        so: `rustup run <toolchain> <COMMAND>`. \
-                        The default check action is `cargo check --all`.")
-                        .multiple(true)
-                        .last(true)
+        .arg(
+            Arg::with_name(id::ARG_SEEK_PATH)
+                .long("path")
+                .help("Path to the cargo project directory")
+                .takes_value(true)
+                .value_name("DIR")
+                .validator(|value| {
+                    std::fs::metadata(&value)
+                        .map_err(|_| "Path doesn't exist.".to_string())
+                        .and_then(|m| {
+                            if m.is_dir() {
+                                Ok(())
+                            } else {
+                                Err("Not a directory.".to_string())
+                            }
+                        })
+                }),
+        )
+        .arg(
+            Arg::with_name(id::ARG_SEEK_CUSTOM_TARGET)
+                .long("target")
+                .help("Check against a custom target (instead of the rustup default)")
+                .takes_value(true)
+                .value_name("TARGET")
+                .validator(|value| {
+                    is_target_available(&value).map_err(|_| {
+                        "The provided target is not available. Use `rustup target list` to \
+                         review the available targets."
+                            .to_string()
+                    })
+                }),
+        )
+        .arg(Arg::with_name(id::ARG_INCLUDE_ALL_PATCH_RELEASES)
+            .long("include-all-patch-releases")
+            .help("Include all patch releases, instead of only the last")
+            .takes_value(false)
+        )
+        .arg(Arg::with_name(id::ARG_MIN)
+            .long("min")
+            .visible_alias("minimum")
+            .help("Earliest version to take into account")
+            .long_help("Earliest (least recent) version to take into account. \
+             Version must match a valid Rust toolchain, and be semver compatible. Edition aliases may also be used.")
+            .takes_value(true)
+        )
+        .arg(Arg::with_name(id::ARG_MAX)
+            .long("max")
+            .visible_alias("maximum")
+            .help("Latest version to take into account")
+            .long_help("Latest (most recent) version to take into account.\
+             Version must match a valid Rust toolchain, and be semver compatible.")
+            .takes_value(true)
+        )
+        .arg(Arg::with_name(id::ARG_BISECT)
+            .long("bisect")
+            .help("Use a binary search to find the MSRV instead of a linear search")
+            .takes_value(false)
+        )
+        .arg(Arg::with_name(id::ARG_TOOLCHAIN_FILE)
+            .long("toolchain-file")
+            .help("Output a rust-toolchain file with the MSRV as toolchain")
+            .long_help("Output a rust-toolchain file with the MSRV as toolchain. \
+            The toolchain file will pin the Rust version for this crate. \
+            See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file for more.")
+        )
+        .arg(Arg::with_name(id::ARG_IGNORE_LOCKFILE)
+            .long("ignore-lockfile")
+            .help("Temporarily removes the lockfile, so it will not interfere with the building process")
+            .long_help("Temporarily removes the lockfile, so it will not interfere with the building process. \
+            This is important when testing against Rust versions prior to 1.38.0, for which Cargo does not recognize the new v2 lockfile.")
+        )
+        .arg(Arg::with_name(id::ARG_OUTPUT_FORMAT)
+            .long("output-format")
+            .help("Output status messages in machine-readable format")
+            .takes_value(true)
+            .possible_values(&["json"])
+            .long_help("Output status messages in machine-readable format. \
+        Machine-readable status updates will be printed in the requested format to stdout.")
+        )
+        .arg(Arg::with_name(id::ARG_VERIFY)
+            .long("verify")
+            .help("Verify the MSRV defined in the 'package.rust-version' or the 'package.metadata.msrv' key in Cargo.toml")
+            .long_help("Verify the MSRV defined in the 'package.rust-version' or the 'package.metadata.msrv' key in Cargo.toml. \
+            When this flag is present, cargo-msrv will not attempt to determine the true MSRV. \
+            Instead it attempts to verify whether for the specified MSRV, the `check` command passes. This is similar to \
+            how we determine whether a Rust toolchain version is compatible for your crate or not.")
+            .takes_value(false)
+        )
+        .arg(Arg::with_name(id::ARG_RELEASE_SOURCE)
+            .long("release-source")
+            .help("Select the rust-releases source to use as the release index")
+            .takes_value(true)
+            .possible_values(&["rust-changelog", "rust-dist"])
+            .default_value("rust-changelog")
+        )
+        .arg(Arg::with_name(id::ARG_NO_LOG)
+            .long("no-log")
+            .help("Disable logging")
+            .takes_value(false)
+        )
+        .arg(Arg::with_name(id::ARG_NO_READ_MIN_EDITION)
+            .long("no-read-min-edition")
+            .help("If provided, the 'package.edition' value in the Cargo.toml will not \
+            be used to reduce search space.")
+            .takes_value(false)
+        )
+        .arg(
+            Arg::with_name(id::ARG_CUSTOM_CHECK)
+                .value_name("COMMAND")
+                .help("If given, this command is used to validate if a Rust version is \
+                compatible. Should be available to rustup, i.e. the command should work like \
+                so: `rustup run <toolchain> <COMMAND>`. \
+                The default check action is `cargo check --all`.")
+                .multiple(true)
+                .last(true)
 
-                )
         )
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -259,11 +259,7 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
         use crate::cli::id;
         use crate::fetch::default_target;
 
-        let arg_matches = matches
-            .subcommand_matches(id::SUB_COMMAND_MSRV)
-            .ok_or(CargoMSRVError::UnableToParseCliArgs)?;
-
-        let action_intent = if arg_matches.is_present(id::ARG_VERIFY) {
+        let action_intent = if matches.is_present(id::ARG_VERIFY) {
             ModeIntent::VerifyMSRV
         } else {
             ModeIntent::DetermineMSRV
@@ -275,24 +271,24 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
         let mut builder = ConfigBuilder::new(action_intent, &target);
 
         // set the command which will be used to check if a project can build
-        let check_cmd = arg_matches.values_of(id::ARG_CUSTOM_CHECK);
+        let check_cmd = matches.values_of(id::ARG_CUSTOM_CHECK);
         if let Some(cmd) = check_cmd {
             builder = builder.check_command(cmd.collect());
         }
 
         // set the cargo workspace path
-        let crate_path = arg_matches.value_of(id::ARG_SEEK_PATH);
+        let crate_path = matches.value_of(id::ARG_SEEK_PATH);
         builder = builder.crate_path(crate_path);
 
         // set a custom target
-        let custom_target = arg_matches.value_of(id::ARG_SEEK_CUSTOM_TARGET);
+        let custom_target = matches.value_of(id::ARG_SEEK_CUSTOM_TARGET);
         if let Some(target) = custom_target {
             builder = builder.target(target);
         }
 
-        match arg_matches.value_of(id::ARG_MIN) {
+        match matches.value_of(id::ARG_MIN) {
             Some(min) => builder = builder.minimum_version(parse_version(min)?),
-            None if arg_matches.is_present(id::ARG_NO_READ_MIN_EDITION) => {}
+            None if matches.is_present(id::ARG_NO_READ_MIN_EDITION) => {}
             None => {
                 let crate_folder = if let Some(ref path) = builder.inner.crate_path {
                     Ok(path.to_path_buf())
@@ -315,20 +311,20 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
             }
         }
 
-        if let Some(max) = arg_matches.value_of(id::ARG_MAX) {
+        if let Some(max) = matches.value_of(id::ARG_MAX) {
             builder = builder.maximum_version(rust_releases::semver::Version::parse(max)?)
         }
 
-        builder = builder.bisect(arg_matches.is_present(id::ARG_BISECT));
+        builder = builder.bisect(matches.is_present(id::ARG_BISECT));
 
         builder = builder
-            .include_all_patch_releases(arg_matches.is_present(id::ARG_INCLUDE_ALL_PATCH_RELEASES));
+            .include_all_patch_releases(matches.is_present(id::ARG_INCLUDE_ALL_PATCH_RELEASES));
 
-        builder = builder.output_toolchain_file(arg_matches.is_present(id::ARG_TOOLCHAIN_FILE));
+        builder = builder.output_toolchain_file(matches.is_present(id::ARG_TOOLCHAIN_FILE));
 
-        builder = builder.ignore_lockfile(arg_matches.is_present(id::ARG_IGNORE_LOCKFILE));
+        builder = builder.ignore_lockfile(matches.is_present(id::ARG_IGNORE_LOCKFILE));
 
-        let output_format = arg_matches.value_of(id::ARG_OUTPUT_FORMAT);
+        let output_format = matches.value_of(id::ARG_OUTPUT_FORMAT);
         if let Some(output_format) = output_format {
             let output_format = match output_format {
                 "json" => OutputFormat::Json,
@@ -338,13 +334,13 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
             builder = builder.output_format(output_format);
         }
 
-        let release_source = arg_matches.value_of(id::ARG_RELEASE_SOURCE);
+        let release_source = matches.value_of(id::ARG_RELEASE_SOURCE);
         if let Some(release_source) = release_source {
             let release_source = ReleaseSource::try_from(release_source)?;
             builder = builder.release_source(release_source);
         }
 
-        builder = builder.no_tracing(arg_matches.is_present(id::ARG_NO_LOG));
+        builder = builder.no_tracing(matches.is_present(id::ARG_NO_LOG));
 
         Ok(builder.build())
     }

--- a/tests/find_msrv.rs
+++ b/tests/find_msrv.rs
@@ -24,7 +24,7 @@ fn msrv_using_linear_method(folder: &str, expected_version: semver::Version) {
     let folder = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("features")
         .join(folder);
-    let with_args = vec!["cargo", "msrv", "--path", folder.to_str().unwrap()];
+    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
 
     let result = run_msrv(with_args);
     let actual_version = result.unwrap_version();
@@ -50,7 +50,7 @@ fn msrv_using_bisect_method(folder: &str, expected_version: semver::Version) {
     let folder = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("features")
         .join(folder);
-    let with_args = vec!["cargo", "msrv", "--path", folder.to_str().unwrap()];
+    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
 
     let result = run_msrv(with_args);
     let actual_version = result.unwrap_version();
@@ -63,7 +63,7 @@ fn msrv_unsupported() {
     let folder = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("features")
         .join("unbuildable");
-    let with_args = vec!["cargo", "msrv", "--path", folder.to_str().unwrap()];
+    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
 
     let result = run_msrv(with_args);
     assert_eq!(result, MinimalCompatibility::NoCompatibleToolchains);
@@ -88,8 +88,7 @@ fn msrv_with_custom_command(folder: &str, expected_version: semver::Version) {
         .join("features")
         .join(folder);
     let with_args = vec![
-        "cargo",
-        "msrv",
+        "cargo-msrv",
         "--path",
         folder.to_str().unwrap(),
         "--",
@@ -122,8 +121,7 @@ fn msrv_with_release_source(release_source: &str, folder: &str, expected_version
         .join("features")
         .join(folder);
     let with_args = vec![
-        "cargo",
-        "msrv",
+        "cargo-msrv",
         "--release-source",
         release_source,
         "--path",
@@ -146,8 +144,7 @@ fn msrv_with_old_lockfile() {
         .join("features")
         .join("1.29.2");
     let with_args = vec![
-        "cargo",
-        "msrv",
+        "cargo-msrv",
         "--path",
         folder.to_str().unwrap(),
         "--ignore-lockfile",
@@ -166,7 +163,7 @@ mod minimum_from_edition {
         let folder = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("features")
             .join("1.30.0");
-        let with_args = vec!["cargo", "msrv", "--path", folder.to_str().unwrap()];
+        let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
 
         let versions = vec![
             Release::new_stable(semver::Version::new(1, 32, 0)),
@@ -191,8 +188,7 @@ mod minimum_from_edition {
             .join("features")
             .join("1.30.0");
         let with_args = vec![
-            "cargo",
-            "msrv",
+            "cargo-msrv",
             "--path",
             folder.to_str().unwrap(),
             "--no-read-min-edition",

--- a/tests/verify_msrv.rs
+++ b/tests/verify_msrv.rs
@@ -17,7 +17,7 @@ fn verify(folder: &str) {
     let folder = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("features")
         .join(folder);
-    let with_args = vec!["cargo", "msrv", "--path", folder.to_str().unwrap()];
+    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
 
     let result = run_verify(
         with_args,
@@ -43,7 +43,7 @@ fn verify_failed_no_msrv_specified(folder: &str) {
     let folder = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("features")
         .join(folder);
-    let with_args = vec!["cargo", "msrv", "--path", folder.to_str().unwrap()];
+    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
 
     let result = run_verify(
         with_args,


### PR DESCRIPTION
Standalone in this context means that the program will run not run as a cargo subcommand (i.e. `cargo-program` or `program` instead of `cargo program`).