### PR TITLE
Install the latest Rust version for release build action

### DIFF
--- a/.github/workflows/build-release-binaries.yaml
+++ b/.github/workflows/build-release-binaries.yaml
@@ -13,12 +13,15 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
+            rust: stable
           - target: x86_64-apple-darwin
             os: macos-latest
             archive_ext: tar
+            rust: stable
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             archive_ext: zip
+            rust: stable
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout_tagged_commit
@@ -26,7 +29,12 @@ jobs:
         with:
           ref: ${{ github.event.release.target_commitish }}
 
-      - uses: Swatinem/rust-cache@v1.3.0
+      - name: install_rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
 
       - name: build_${{ matrix.target }}_release_binary
         run: cargo build --target=${{ matrix.target }} --release


### PR DESCRIPTION
This is necessary since cargo about already updated to rust 2021, so to compile it we need at least Rust version 1.56, while so far Rust version 1.55 was available.

In addition, taking the latest stable may add new optimizations not available on earlier versions.

A disadvantage is the extra added toolchain install time.

Also removed the rust-cache since it never really had any hits, and to ensure it isn't interfering with the toolchain version.