### PR TITLE
Add options to configure logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "dirs",
  "indicatif",
  "json",
+ "once_cell",
  "parameterized",
  "petgraph",
  "rust-releases",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ comfy-table = "4.1.1"
 
 typed-builder = "0.9.1"
 
+once_cell = "1.8.0"
+
 [dependencies.tracing-subscriber]
 version = "0.3"
 features = ["json"]

--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -56,7 +56,7 @@ fn _main<I: IntoIterator<Item = String>, F: FnOnce() -> I>(
     let mut guard = Option::None;
 
     if let Some(options) = config.tracing() {
-        let tracing_config = TracingConfig::try_from_options(&options)?;
+        let tracing_config = TracingConfig::try_from_options(options)?;
         guard = Some(init_tracing(&tracing_config)?);
     }
 

--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -1,9 +1,9 @@
 use std::convert::TryFrom;
+use std::path::{Path, PathBuf};
 
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
-use tracing_subscriber::filter::LevelFilter;
 
-use cargo_msrv::config::{self, Config, ModeIntent};
+use cargo_msrv::config::{self, Config, ModeIntent, TracingOptions, TracingTargetOption};
 use cargo_msrv::errors::{CargoMSRVError, TResult};
 use cargo_msrv::reporter;
 use cargo_msrv::{cli, run_app};
@@ -45,7 +45,7 @@ fn args() -> impl IntoIterator<Item = String> {
 
 fn _main<I: IntoIterator<Item = String>, F: FnOnce() -> I>(
     args: F,
-) -> TResult<Option<tracing_appender::non_blocking::WorkerGuard>> {
+) -> TResult<Option<TracingGuard>> {
     let matches = cli::cli().get_matches_from(args());
     let config = Config::try_from(&matches)?;
 
@@ -55,8 +55,9 @@ fn _main<I: IntoIterator<Item = String>, F: FnOnce() -> I>(
     // `init_and_run` would not be logged.
     let mut guard = Option::None;
 
-    if !config.no_tracing() {
-        guard = Some(init_tracing()?);
+    if let Some(options) = config.tracing() {
+        let tracing_config = TracingConfig::try_from_options(&options)?;
+        guard = Some(init_tracing(&tracing_config)?);
     }
 
     init_and_run(&config)?;
@@ -65,7 +66,10 @@ fn _main<I: IntoIterator<Item = String>, F: FnOnce() -> I>(
 }
 
 fn init_and_run(config: &Config) -> TResult<()> {
-    tracing::info!("Running app");
+    tracing::info!(
+        cargo_msrv_version = env!("CARGO_PKG_VERSION"),
+        "initializing"
+    );
 
     match config.output_format() {
         config::OutputFormat::Human => {
@@ -97,27 +101,97 @@ fn init_and_run(config: &Config) -> TResult<()> {
         }
     }?;
 
-    tracing::info!("Finished app");
+    tracing::info!("finished");
 
     Ok(())
 }
 
-fn init_tracing() -> TResult<tracing_appender::non_blocking::WorkerGuard> {
-    let log_folder = dirs::data_local_dir()
-        .map(|path| path.join("cargo-msrv"))
-        .ok_or(CargoMSRVError::UnableToAccessLogFolder)?;
+fn init_tracing(tracing_config: &TracingConfig) -> TResult<TracingGuard> {
+    let level = tracing_config.level;
 
+    match &tracing_config.target {
+        // Log (non-blocking) to disk
+        TracingTarget::ToDisk(path) => {
+            let guard = init_tracing_to_file(path, level);
+
+            let folder = format!("{}", path.display());
+            tracing::debug!(log_folder = folder.as_str());
+
+            guard
+        }
+        // Log to stdout
+        TracingTarget::Stdout => init_tracing_to_stdout(level),
+    }
+}
+
+fn init_tracing_to_file(
+    log_folder: impl AsRef<Path>,
+    level: tracing::Level,
+) -> TResult<TracingGuard> {
     let file_appender = RollingFileAppender::new(Rotation::DAILY, log_folder, "cargo-msrv-log");
     let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
     let subscriber = tracing_subscriber::fmt()
         .json()
-        .with_max_level(LevelFilter::INFO)
+        .with_max_level(level)
         .with_writer(non_blocking)
         .finish();
 
     tracing::subscriber::set_global_default(subscriber)
         .map_err(|_| CargoMSRVError::UnableToInitTracing)?;
 
-    Ok(guard)
+    Ok(TracingGuard::NonBlockingGuard(guard))
+}
+
+fn init_tracing_to_stdout(level: tracing::Level) -> TResult<TracingGuard> {
+    let subscriber = tracing_subscriber::fmt().with_max_level(level).finish();
+
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|_| CargoMSRVError::UnableToInitTracing)?;
+
+    Ok(TracingGuard::None)
+}
+
+struct TracingConfig {
+    level: tracing::Level,
+    target: TracingTarget,
+}
+
+impl TracingConfig {
+    fn try_from_options(config: &TracingOptions) -> TResult<Self> {
+        let target = TracingTarget::try_from_option(config.target())?;
+
+        Ok(TracingConfig {
+            level: *config.level(),
+            target,
+        })
+    }
+}
+
+enum TracingTarget {
+    ToDisk(PathBuf),
+    Stdout,
+}
+
+impl TracingTarget {
+    fn try_from_option(option: &TracingTargetOption) -> TResult<Self> {
+        match option {
+            TracingTargetOption::File => {
+                let folder = log_folder()?;
+                Ok(TracingTarget::ToDisk(folder))
+            }
+            TracingTargetOption::Stdout => Ok(TracingTarget::Stdout),
+        }
+    }
+}
+
+enum TracingGuard {
+    NonBlockingGuard(tracing_appender::non_blocking::WorkerGuard),
+    None,
+}
+
+fn log_folder() -> TResult<PathBuf> {
+    dirs::data_local_dir()
+        .map(|path| path.join("cargo-msrv"))
+        .ok_or(CargoMSRVError::UnableToAccessLogFolder)
 }

--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -89,8 +89,9 @@ fn init_and_run(config: &Config) -> TResult<()> {
             run_app(config, &reporter)
         }
         config::OutputFormat::None => {
-            // for testing without any output
-            let reporter = reporter::__private::NoOutput;
+            // To disable regular output. Useful when outputting logs to stdout, as the
+            //   regular output and the log output may otherwise interfere with each other.
+            let reporter = reporter::no_output::NoOutput;
 
             run_app(config, &reporter)
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::config::TracingTargetOption;
 use clap::{App, AppSettings, Arg};
 
 use crate::fetch::is_target_available;
@@ -16,6 +17,8 @@ pub mod id {
     pub const ARG_VERIFY: &str = "verify_msrv";
     pub const ARG_RELEASE_SOURCE: &str = "release_source";
     pub const ARG_NO_LOG: &str = "no_log";
+    pub const ARG_LOG_LEVEL: &str = "log_level";
+    pub const ARG_LOG_TARGET: &str = "log_target";
     pub const ARG_NO_READ_MIN_EDITION: &str = "no_read_min_edition";
 
     pub const SUB_COMMAND_LIST: &str = "list";
@@ -142,6 +145,22 @@ rustup like so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provi
             .long("no-log")
             .help("Disable logging")
             .takes_value(false)
+        )
+        .arg(Arg::with_name(id::ARG_LOG_TARGET)
+            .long("log-target")
+            .help("Specify where the program should output its logs")
+            .takes_value(true)
+            .number_of_values(1)
+            .possible_values(&[TracingTargetOption::FILE, TracingTargetOption::STDOUT])
+            .default_value(TracingTargetOption::FILE)
+        )
+        .arg(Arg::with_name(id::ARG_LOG_LEVEL)
+            .long("log-level")
+            .help("Specify the verbosity of logs the program should output")
+            .takes_value(true)
+            .number_of_values(1)
+            .possible_values(&["error", "warn", "info", "debug", "trace"])
+            .default_value("info")
         )
         .arg(Arg::with_name(id::ARG_NO_READ_MIN_EDITION)
             .long("no-read-min-edition")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::config::TracingTargetOption;
+use crate::config::{OutputFormat, TracingTargetOption};
 use clap::{App, AppSettings, Arg};
 
 use crate::fetch::is_target_available;
@@ -121,7 +121,7 @@ rustup like so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provi
             .long("output-format")
             .help("Output status messages in machine-readable format")
             .takes_value(true)
-            .possible_values(&["json"])
+            .possible_values(OutputFormat::custom_formats())
             .long_help("Output status messages in machine-readable format. \
         Machine-readable status updates will be printed in the requested format to stdout.")
         )

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,49 +1,117 @@
-use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::path::Path;
-use std::process::{Child, Command, Stdio};
+use std::process::{Command, Stdio};
 
-use crate::errors::TResult;
+use crate::errors::{CargoMSRVError, TResult};
 
-pub fn command_with_output<I: IntoIterator<Item = V>, V: AsRef<OsStr>>(
-    commands: I,
-) -> TResult<Child> {
-    command_impl(commands, None)
-        .pipe_output()
-        .spawn()
-        .map_err(From::from)
+pub struct RustupCommand {
+    command: Command,
+    args: Vec<OsString>,
+    stdout: Stdio,
+    stderr: Stdio,
 }
 
-pub fn command<I: IntoIterator<Item = V>, V: AsRef<OsStr>>(
-    commands: I,
-    dir: Option<&Path>,
-) -> TResult<Child> {
-    command_impl(commands, dir)
-        .pipe_output()
-        .spawn()
-        .map_err(From::from)
-}
+impl RustupCommand {
+    pub fn new() -> Self {
+        Self {
+            command: Command::new("rustup"),
+            args: Vec::new(),
+            stdout: Stdio::null(),
+            stderr: Stdio::null(),
+        }
+    }
 
-trait PipeCliOutput {
-    fn pipe_output(&mut self) -> &mut Command;
-}
+    pub fn with_dir(mut self, path: impl AsRef<Path>) -> Self {
+        let _ = self.command.current_dir(path);
+        self
+    }
 
-impl PipeCliOutput for Command {
-    fn pipe_output(&mut self) -> &mut Command {
-        self.stdout(Stdio::piped());
-        self.stderr(Stdio::piped())
+    pub fn with_optional_dir(self, path: Option<impl AsRef<Path>>) -> Self {
+        if let Some(dir) = path {
+            return self.with_dir(dir);
+        }
+        self
+    }
+
+    pub fn with_args<T: Into<OsString>>(mut self, args: impl IntoIterator<Item = T>) -> Self {
+        let _ = self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    pub fn with_stdout(mut self) -> Self {
+        self.stdout = Stdio::piped();
+        self
+    }
+
+    pub fn with_stderr(mut self) -> Self {
+        self.stderr = Stdio::piped();
+        self
+    }
+
+    /// Execute `rustup run [...]`
+    pub fn run(self) -> TResult<RustupOutput> {
+        self.execute(OsString::from("run"))
+    }
+
+    /// Execute `rustup install [...]`
+    pub fn install(self) -> TResult<RustupOutput> {
+        self.execute(OsString::from("install"))
+    }
+
+    /// Execute `rustup show [...]`
+    pub fn show(self) -> TResult<RustupOutput> {
+        self.execute(OsString::from("show"))
+    }
+
+    /// Execute a given `rustup` command.
+    ///
+    /// See also:
+    /// * [RustupCommand::run](RustupCommand::run)
+    /// * [RustupCommand::install](RustupCommand::run)
+    /// * [RustupCommand::show](RustupCommand::run)
+    pub fn execute(mut self, cmd: OsString) -> TResult<RustupOutput> {
+        debug!(
+            cmd = ?cmd.as_os_str(),
+            args = ?self.args.as_slice()
+        );
+
+        self.command.arg(cmd);
+        self.command.args(self.args);
+
+        self.command.stdout(self.stdout);
+        self.command.stderr(self.stderr);
+
+        let child = self.command.spawn().map_err(CargoMSRVError::Io)?;
+        let output = child.wait_with_output()?;
+
+        Ok(RustupOutput {
+            output,
+            stdout: once_cell::sync::OnceCell::new(),
+            stderr: once_cell::sync::OnceCell::new(),
+        })
     }
 }
 
-fn command_impl<I: IntoIterator<Item = V>, V: AsRef<OsStr>>(
-    commands: I,
-    current_dir: Option<&Path>,
-) -> Command {
-    let mut cmd = Command::new("rustup");
-    let _ = cmd.args(commands);
+pub struct RustupOutput {
+    output: std::process::Output,
+    stdout: once_cell::sync::OnceCell<String>,
+    stderr: once_cell::sync::OnceCell<String>,
+}
 
-    if let Some(dir) = current_dir {
-        let _ = cmd.current_dir(dir);
+impl RustupOutput {
+    pub fn stdout(&self) -> &str {
+        self.stdout
+            .get_or_init(|| String::from_utf8_lossy(&self.output.stdout).into_owned())
+            .as_str()
     }
 
-    cmd
+    pub fn stderr(&self) -> &str {
+        self.stderr
+            .get_or_init(|| String::from_utf8_lossy(&self.output.stderr).into_owned())
+            .as_str()
+    }
+
+    pub fn exit_status(&self) -> std::process::ExitStatus {
+        self.output.status
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@ pub enum OutputFormat {
     Human,
     /// Json status updates printed to stdout
     Json,
-    /// No output -- meant to be used for testing
+    /// No output -- meant to be used for debugging and testing
     None,
     /// Save all versions tested and save success result for all runs -- meant to be used for testing
     TestSuccesses,
@@ -25,6 +25,17 @@ pub enum OutputFormat {
 impl Default for OutputFormat {
     fn default() -> Self {
         Self::Human
+    }
+}
+
+impl OutputFormat {
+    pub const JSON: &'static str = "json";
+    pub const NONE: &'static str = "void";
+
+    /// A set of formats which may be given as a configuration option
+    ///   through the CLI.
+    pub fn custom_formats() -> &'static [&'static str] {
+        &[Self::JSON, Self::NONE]
     }
 }
 
@@ -368,7 +379,8 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
         let output_format = matches.value_of(id::ARG_OUTPUT_FORMAT);
         if let Some(output_format) = output_format {
             let output_format = match output_format {
-                "json" => OutputFormat::Json,
+                OutputFormat::JSON => OutputFormat::Json,
+                OutputFormat::NONE => OutputFormat::None,
                 _ => unreachable!(),
             };
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,92 +1,49 @@
-use crate::command::command_with_output;
+use crate::command::RustupCommand;
 use crate::errors::{CargoMSRVError, TResult};
+use std::ffi::OsString;
 
 pub type ToolchainSpecifier = String;
-
-#[allow(unused)]
-/// Verify that the given toolchain is installed.
-/// with `rustup toolchain list`
-pub fn is_toolchain_installed<S: AsRef<str>>(name: S) -> TResult<()> {
-    let toolchain = name.as_ref();
-    command_with_output(&["toolchain", "list"]).and_then(|child| {
-        let output = child.wait_with_output()?;
-
-        String::from_utf8(output.stdout)
-            .map_err(From::from)
-            .and_then(|string| {
-                let mut lines = string.lines();
-
-                // the default toolchain is formatted like so:
-                // <toolchain> (default)
-                if let Some(first) = lines.next() {
-                    if let Some(default) = first.split_ascii_whitespace().next() {
-                        if default == toolchain {
-                            return Ok(());
-                        }
-                    }
-                }
-
-                // after the default toolchain, all other installed toolchains are listed
-                // one per line
-                for line in lines {
-                    if line == toolchain {
-                        return Ok(());
-                    }
-                }
-
-                Err(CargoMSRVError::ToolchainNotInstalled)
-            })
-    })
-}
 
 /// Check if the given target is available.
 /// with `rustup target list`
 pub fn is_target_available<S: AsRef<str>>(name: S) -> TResult<()> {
     let toolchain = name.as_ref();
-    command_with_output(&["target", "list"]).and_then(|child| {
-        let output = child.wait_with_output()?;
+    let output = RustupCommand::new()
+        .with_stdout()
+        .with_args(&["list"])
+        .execute(OsString::from("target"))?;
 
-        String::from_utf8(output.stdout)
-            .map_err(From::from)
-            .and_then(|string| {
-                // Each target is listed on a single line.
-                // If a target is installed, it is listed as <target> (installed).
-                // If a target is the default, it is listed as <target> (default).
-                for line in string.lines() {
-                    if let Some(it) = line.split_ascii_whitespace().next() {
-                        if it == toolchain {
-                            return Ok(());
-                        }
-                    }
-                }
+    let stdout = output.stdout();
 
-                Err(CargoMSRVError::UnknownTarget)
-            })
-    })
+    // Each target is listed on a single line.
+    // If a target is installed, it is listed as <target> (installed).
+    // If a target is the default, it is listed as <target> (default).
+    for line in stdout.lines() {
+        if let Some(it) = line.split_ascii_whitespace().next() {
+            if it == toolchain {
+                return Ok(());
+            }
+        }
+    }
+
+    Err(CargoMSRVError::UnknownTarget)
 }
 
 /// Uses the `.rustup/settings.toml` file to determine the default target (aka the
 /// `default_host_triple`) if not set by a user.
 pub fn default_target() -> TResult<String> {
-    command_with_output(&["show"]).and_then(|child| {
-        let output = child.wait_with_output()?;
+    let output = RustupCommand::new().with_stdout().show()?;
 
-        String::from_utf8(output.stdout)
-            .map_err(From::from)
-            .and_then(|string| {
-                // the first line contains the default target
-                // e.g. `Default host: x86_64-unknown-linux-gnu`
+    let stdout = output.stdout();
 
-                string
-                    .lines()
-                    .next()
-                    .ok_or(CargoMSRVError::DefaultHostTripleNotFound)
-                    .and_then(|line| {
-                        line.split_ascii_whitespace()
-                            .nth(2)
-                            .ok_or(CargoMSRVError::DefaultHostTripleNotFound)
-                            .map(String::from)
-                    })
-            })
-    })
+    stdout
+        .lines()
+        .next()
+        .ok_or(CargoMSRVError::DefaultHostTripleNotFound)
+        .and_then(|line| {
+            line.split_ascii_whitespace()
+                .nth(2)
+                .ok_or(CargoMSRVError::DefaultHostTripleNotFound)
+                .map(String::from)
+        })
 }

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -5,6 +5,7 @@ use rust_releases::semver;
 use crate::config::ModeIntent;
 
 pub mod json;
+pub mod no_output;
 pub mod ui;
 
 #[derive(Debug, Clone, Copy)]
@@ -38,20 +39,6 @@ pub mod __private {
 
     use crate::config::ModeIntent;
     use crate::reporter::{Output, ProgressAction};
-
-    /// This is meant to be used for testing
-    #[derive(Debug)]
-    pub struct NoOutput;
-
-    impl Output for NoOutput {
-        fn mode(&self, _action: ModeIntent) {}
-        fn set_steps(&self, _steps: u64) {}
-        fn progress(&self, _action: ProgressAction) {}
-        fn complete_step(&self, _version: &semver::Version, _success: bool) {}
-        fn finish_success(&self, _mode: ModeIntent, _version: Option<&semver::Version>) {}
-        fn finish_failure(&self, _mode: ModeIntent, _cmd: Option<&str>) {}
-        fn write_line(&self, _content: &str) {}
-    }
 
     /// This is meant to be used for testing
     #[derive(Debug)]

--- a/src/reporter/no_output.rs
+++ b/src/reporter/no_output.rs
@@ -1,0 +1,14 @@
+use crate::{semver, ModeIntent, Output, ProgressAction};
+
+#[derive(Debug)]
+pub struct NoOutput;
+
+impl Output for NoOutput {
+    fn mode(&self, _action: ModeIntent) {}
+    fn set_steps(&self, _steps: u64) {}
+    fn progress(&self, _action: ProgressAction) {}
+    fn complete_step(&self, _version: &semver::Version, _success: bool) {}
+    fn finish_success(&self, _mode: ModeIntent, _version: Option<&semver::Version>) {}
+    fn finish_failure(&self, _mode: ModeIntent, _cmd: Option<&str>) {}
+    fn write_line(&self, _content: &str) {}
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,12 +8,12 @@ use rust_releases::{semver, Release, ReleaseIndex};
 
 use cargo_msrv::config::{test_config_from_matches, Config, OutputFormat};
 use cargo_msrv::errors::TResult;
-use cargo_msrv::reporter;
-use cargo_msrv::reporter::__private::{NoOutput, SuccessOutput};
+use cargo_msrv::reporter::__private::SuccessOutput;
 use cargo_msrv::reporter::json::JsonPrinter;
+use cargo_msrv::reporter::no_output::NoOutput;
 use cargo_msrv::reporter::ui::HumanPrinter;
 use cargo_msrv::reporter::Output;
-use cargo_msrv::MinimalCompatibility;
+use cargo_msrv::{reporter, MinimalCompatibility};
 
 pub fn run_msrv<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(
     with_args: I,
@@ -112,8 +112,8 @@ pub fn run_cargo_version_which_doesnt_support_lockfile_v2<
         .expect("Unable to run MSRV process")
 }
 
-pub fn fake_reporter() -> reporter::__private::NoOutput {
-    reporter::__private::NoOutput
+pub fn fake_reporter() -> reporter::no_output::NoOutput {
+    reporter::no_output::NoOutput
 }
 
 pub fn test_reporter() -> reporter::__private::SuccessOutput {


### PR DESCRIPTION
* Add options to specify the log target and log severity
* Replaced command and command_with_output with `RustupCommand` and `RustupOutput`
  * The `RustupCommand` allows builder style configuration and initialization of a command, tailored specifically towards 'rustup'
  * `RustupOutput` makes stdout, stderr and and the exit status more conveniently accessable than a regular `std:process::Output`.
* Allow users to disable regular output completely 
  * Especially useful when printing logs to stdout with log-target=stdout.