### PR TITLE
Refactor formatting of 'list' command (1/3)

### DIFF
--- a/src/dependencies/formatter/mod.rs
+++ b/src/dependencies/formatter/mod.rs
@@ -1,6 +1,5 @@
 use crate::manifest::{bare_version::BareVersion, CargoManifest, CargoManifestParser, TomlParser};
 use cargo_metadata::Package;
-pub(crate) use direct_deps::DirectDependenciesFormatter;
 pub(crate) use ordered_by_msrv::ByMSRVFormatter;
 use rust_releases::semver::Version;
 use std::convert::TryFrom;

--- a/src/subcommands/list.rs
+++ b/src/subcommands/list.rs
@@ -1,5 +1,6 @@
 use crate::config::list::ListVariant;
 use crate::config::{Config, ModeIntent, OutputFormat};
+use crate::dependencies::formatter::direct_deps;
 use crate::dependencies::resolver::{CargoMetadataResolver, DependencyResolver};
 use crate::errors::TResult;
 use crate::reporter::Output;
@@ -12,33 +13,26 @@ pub fn run_list_msrv<R: Output>(config: &Config, output: &R) -> TResult<()> {
     let resolver = CargoMetadataResolver::try_from_config(config)?;
     let graph = resolver.resolve()?;
 
-    match config.sub_command_config().list().variant {
-        ListVariant::DirectDeps => match config.output_format() {
-            OutputFormat::Human => {
-                use crate::reporter::ui::HumanPrinter;
-                let formatter = formatter::DirectDependenciesFormatter::<HumanPrinter>::new(graph);
-                output.write_line(&format!("{}", formatter));
-            }
-            OutputFormat::Json => {
-                use crate::reporter::json::JsonPrinter;
-                let formatter = formatter::DirectDependenciesFormatter::<JsonPrinter>::new(graph);
-                output.write_line(&format!("{}", formatter));
-            }
-            OutputFormat::None | OutputFormat::TestSuccesses => {}
-        },
-        ListVariant::OrderedByMSRV => match config.output_format() {
+    let format = config.output_format();
+    let variant = config.sub_command_config().list().variant;
+
+    if let Some(s) = match variant {
+        ListVariant::DirectDeps => direct_deps::format(format, &graph),
+        ListVariant::OrderedByMSRV => match format {
             OutputFormat::Human => {
                 use crate::reporter::ui::HumanPrinter;
                 let formatter = formatter::ByMSRVFormatter::<HumanPrinter>::new(graph);
-                output.write_line(&format!("{}", formatter));
+                Some(formatter.to_string())
             }
             OutputFormat::Json => {
                 use crate::reporter::json::JsonPrinter;
                 let formatter = formatter::ByMSRVFormatter::<JsonPrinter>::new(graph);
-                output.write_line(&format!("{}", formatter));
+                Some(formatter.to_string())
             }
-            OutputFormat::None | OutputFormat::TestSuccesses => {}
+            OutputFormat::None | OutputFormat::TestSuccesses => None,
         },
+    } {
+        output.write_line(&s)
     }
 
     output.finish_success(ModeIntent::List, None);


### PR DESCRIPTION
this is a partial refactor of the `dependencies.formatter` module.

still more to do, but this is a reasonable incremental change

(it's fairly complex, so i didn't want to make the diff too big)

i've gotten rid of the unnecessary state, I think the functional approach is dramatically cleaner here. Still not convinced about the separation of concerns though. I feel like the formatting would maybe be better living with the subcommand logic, and not in a separate module. That's a problem for another day