### PR TITLE
remove 'typed-builder' dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "typed-builder",
  "yare",
 ]
 
@@ -1768,17 +1767,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "typed-builder"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46ee5bd706ff79131be9c94e7edcb82b703c487766a114434e5790361cf08c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,6 @@ cargo_metadata = "0.14.1"
 petgraph = "0.6.0"
 comfy-table = "4.1.1"
 
-typed-builder = "0.9.1"
-
 once_cell = "1.9.0"
 thiserror = "1.0.30"
 

--- a/src/config/list.rs
+++ b/src/config/list.rs
@@ -1,29 +1,24 @@
 use clap::ArgMatches;
-use std::str::FromStr;
-use typed_builder::TypedBuilder;
+use std::{convert::TryFrom, str::FromStr};
 
-#[derive(Clone, Debug, TypedBuilder)]
+#[derive(Clone, Debug)]
 pub struct ListCmdConfig {
-    #[builder(default)]
     pub variant: ListVariant,
 }
 
-impl ListCmdConfig {
-    pub fn try_from_args(args: &ArgMatches) -> Result<Self, crate::CargoMSRVError> {
+impl<'a> TryFrom<&'a ArgMatches<'a>> for ListCmdConfig {
+    type Error = crate::CargoMSRVError;
+
+    fn try_from(args: &'a ArgMatches) -> Result<Self, Self::Error> {
         use crate::cli::id;
 
         let variant = if let Some(var) = args.value_of(id::SUB_COMMAND_LIST_VARIANT) {
-            let typ = ListVariant::from_str(var)?;
-            Some(typ)
+            ListVariant::from_str(var)?
         } else {
-            None
+            ListVariant::default()
         };
 
-        let config = ListCmdConfig::builder()
-            .variant(variant.unwrap_or_default())
-            .build();
-
-        Ok(config)
+        Ok(ListCmdConfig { variant })
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -416,7 +416,7 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
         }
 
         if let Some(cmd) = matches.subcommand_matches(id::SUB_COMMAND_LIST) {
-            let cmd_config = ListCmdConfig::try_from_args(cmd)?;
+            let cmd_config = ListCmdConfig::try_from(cmd)?;
             builder = builder.sub_command_config(SubCommandConfig::ListConfig(cmd_config));
         }
 


### PR DESCRIPTION
the `typed-builder` dependency is not adding a lot of value right now, and it's probably better to just remove it.

additionally, parsing a `ListVariant` from args should be infallible, since this can only fail if there's a bug in the CLI (essentially it can only fail if an invariant in this crate is broken, in which case this *should* panic!)