### PR TITLE
use standard syntax for defining bin entrypoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,3 @@ features = ["rust-releases-rust-changelog", "rust-releases-rust-dist"]
 parameterized = "0.3.1"
 yare = "1.0.1"
 
-[[bin]]
-name = "cargo-msrv"
-path = "src/bin/cargo-msrv.rs"


### PR DESCRIPTION
this PR makes a change to use the standard layout for defining a binary entrypoint. Namely that `src/main.rs` is implicitly treated as a binary target, without needing to be explicitly defined.