### PR TITLE
make 'builder' 'must_use'

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -206,6 +206,7 @@ impl<'a> Config<'a> {
 }
 
 #[derive(Debug, Clone)]
+#[must_use]
 pub struct ConfigBuilder<'a> {
     inner: Config<'a>,
 }


### PR DESCRIPTION
make the `ConfigBuilder` 'must_use'.

There's no valid reason ever to not use a builder struct, hence it makes sense to mark it as `#[must_use]`

note that there's actually a false positive in clippy right now which is related to this - https://github.com/rust-lang/rust-clippy/issues/8140