### PR TITLE
make rust toolchain installation consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,11 @@ jobs:
 
       # install: rust
       - name: install_rust
-        uses: hecrj/setup-rust-action@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust }}
+          override: true
+          profile: minimal
 
       # build / doc / test
       - name: build_all
@@ -86,9 +88,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: install_rust
-        uses: hecrj/setup-rust-action@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true
+          profile: minimal
       - name: install_rustfmt
         run: rustup component add rustfmt
       - name: check_formatting


### PR DESCRIPTION
makes the rust toolchain installation method consistent.

of the two actions used in the CI workflow, the `action-rs` workflow is

- used more often in this repo already
- better maintained
- more widely used