### PR TITLE
Explicitly define code style using .rustfmt.toml rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
       - name: install_rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
           profile: minimal
       - name: install_rustfmt

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,12 @@
+version = "Two"
+use_field_init_shorthand = true
+imports_granularity="Crate"
+wrap_comments = true
+use_try_shorthand = true
+format_code_in_doc_comments = true
+format_strings = true
+normalize_comments = true
+normalize_doc_attributes = true
+remove_nested_parens = true
+reorder_impl_items = true
+group_imports = "StdExternalCrate"

--- a/src/check.rs
+++ b/src/check.rs
@@ -2,12 +2,14 @@ use std::path::Path;
 
 use rust_releases::semver;
 
-use crate::command::RustupCommand;
-use crate::config::Config;
-use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
-use crate::lockfile::{LockfileHandler, CARGO_LOCK};
-use crate::paths::crate_root_folder;
-use crate::reporter::{Output, ProgressAction};
+use crate::{
+    command::RustupCommand,
+    config::Config,
+    errors::{CargoMSRVError, IoErrorSource, TResult},
+    lockfile::{LockfileHandler, CARGO_LOCK},
+    paths::crate_root_folder,
+    reporter::{Output, ProgressAction},
+};
 
 #[derive(Clone, Debug)]
 pub struct Outcome {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,9 @@
-use crate::config::{OutputFormat, TracingTargetOption};
 use clap::{App, AppSettings, Arg};
 
-use crate::fetch::is_target_available;
+use crate::{
+    config::{OutputFormat, TracingTargetOption},
+    fetch::is_target_available,
+};
 
 pub mod id {
     pub const ARG_SEEK_PATH: &str = "seek_path";
@@ -182,8 +184,9 @@ rustup like so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provi
 }
 
 pub fn list() -> App<'static, 'static> {
-    use crate::config::list;
     use clap::SubCommand;
+
+    use crate::config::list;
 
     SubCommand::with_name(id::SUB_COMMAND_LIST)
         .about("List the MSRV's specified by dependency crate authors")

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,8 @@
-use std::ffi::OsString;
-use std::path::Path;
-use std::process::{Command, Stdio};
+use std::{
+    ffi::OsString,
+    path::Path,
+    process::{Command, Stdio},
+};
 
 use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
 

--- a/src/config/list.rs
+++ b/src/config/list.rs
@@ -1,5 +1,6 @@
-use clap::ArgMatches;
 use std::{convert::TryFrom, str::FromStr};
+
+use clap::ArgMatches;
 
 #[derive(Clone, Debug)]
 pub struct ListCmdConfig {
@@ -42,7 +43,7 @@ impl FromStr for ListVariant {
                 return Err(crate::CargoMSRVError::InvalidConfig(format!(
                     "No such list variant '{}'",
                     elsy
-                )))
+                )));
             }
         })
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,12 +1,16 @@
-use std::convert::TryFrom;
-use std::path::{Path, PathBuf};
-use toml_edit::{Document, Item};
+use std::{
+    convert::TryFrom,
+    path::{Path, PathBuf},
+};
 
-use crate::config::list::ListCmdConfig;
 use clap::ArgMatches;
 use rust_releases::semver;
+use toml_edit::{Document, Item};
 
-use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
+use crate::{
+    config::list::ListCmdConfig,
+    errors::{CargoMSRVError, IoErrorSource, TResult},
+};
 
 pub(crate) mod list;
 
@@ -18,7 +22,8 @@ pub enum OutputFormat {
     Json,
     /// No output -- meant to be used for debugging and testing
     None,
-    /// Save all versions tested and save success result for all runs -- meant to be used for testing
+    /// Save all versions tested and save success result for all runs -- meant
+    /// to be used for testing
     TestSuccesses,
 }
 
@@ -191,7 +196,8 @@ impl<'a> Config<'a> {
         self.release_source
     }
 
-    /// Options as to configure tracing (and logging) settings. If absent, tracing will be disabled.
+    /// Options as to configure tracing (and logging) settings. If absent,
+    /// tracing will be disabled.
     pub fn tracing(&self) -> Option<&TracingOptions> {
         self.tracing_config.as_ref()
     }
@@ -301,8 +307,7 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
     type Error = CargoMSRVError;
 
     fn try_from(matches: &'config ArgMatches<'config>) -> Result<Self, Self::Error> {
-        use crate::cli::id;
-        use crate::fetch::default_target;
+        use crate::{cli::id, fetch::default_target};
 
         let action_intent = if matches.subcommand_matches(id::SUB_COMMAND_LIST).is_some() {
             ModeIntent::List
@@ -314,7 +319,8 @@ impl<'config> TryFrom<&'config ArgMatches<'config>> for Config<'config> {
             ModeIntent::DetermineMSRV
         };
 
-        // FIXME: if set, we don't need to do this; in case we can't find it, it may fail here, but atm can't be manually supplied at all
+        // FIXME: if set, we don't need to do this; in case we can't find it, it may
+        // fail here, but atm can't be manually supplied at all
         let target = default_target()?;
 
         let mut builder = ConfigBuilder::new(action_intent, &target);

--- a/src/dependencies/formatter/direct_deps.rs
+++ b/src/dependencies/formatter/direct_deps.rs
@@ -1,9 +1,12 @@
-use crate::dependencies::formatter::{
-    format_version, get_package_metadata_msrv, parse_manifest_workaround,
-};
-use crate::dependencies::DependencyGraph;
-use crate::reporter::Output;
 use std::marker::PhantomData;
+
+use crate::{
+    dependencies::{
+        formatter::{format_version, get_package_metadata_msrv, parse_manifest_workaround},
+        DependencyGraph,
+    },
+    reporter::Output,
+};
 
 pub(crate) struct DirectDependenciesFormatter<T: Output> {
     graph: DependencyGraph,
@@ -74,8 +77,7 @@ impl<T: Output> DirectDependenciesFormatter<T> {
 impl std::fmt::Display for DirectDependenciesFormatter<crate::reporter::ui::HumanPrinter<'_, '_>> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Table of dependencies
-        use comfy_table::presets::UTF8_FULL;
-        use comfy_table::{Cell, ContentArrangement, Table};
+        use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
 
         let table = self.direct_dependencies_msrv(
             || {

--- a/src/dependencies/formatter/mod.rs
+++ b/src/dependencies/formatter/mod.rs
@@ -1,11 +1,12 @@
-use crate::manifest::{bare_version::BareVersion, CargoManifest, CargoManifestParser, TomlParser};
+use std::{convert::TryFrom, path::Path};
+
 use cargo_metadata::Package;
 pub(crate) use direct_deps::DirectDependenciesFormatter;
 pub(crate) use ordered_by_msrv::ByMSRVFormatter;
 use rust_releases::semver::Version;
-use std::convert::TryFrom;
-use std::path::Path;
 use toml_edit::Document;
+
+use crate::manifest::{bare_version::BareVersion, CargoManifest, CargoManifestParser, TomlParser};
 
 pub mod direct_deps;
 pub mod ordered_by_msrv;
@@ -27,8 +28,8 @@ pub(super) fn format_version(version_req: Option<&crate::semver::Version>) -> St
     }
 }
 
-// Workaround: manual parsing since current (1.56) version of cargo-metadata doesn't yet output the
-//  rust-version
+// Workaround: manual parsing since current (1.56) version of cargo-metadata
+// doesn't yet output the  rust-version
 pub(super) fn parse_manifest_workaround<P: AsRef<Path>>(path: P) -> Option<crate::semver::Version> {
     fn parse(path: &Path) -> Option<Version> {
         std::fs::read_to_string(path)

--- a/src/dependencies/formatter/ordered_by_msrv.rs
+++ b/src/dependencies/formatter/ordered_by_msrv.rs
@@ -1,15 +1,18 @@
-use crate::dependencies::formatter::{
-    format_version, get_package_metadata_msrv, parse_manifest_workaround,
-};
-use crate::dependencies::DependencyGraph;
-use crate::reporter::Output;
+use std::{collections::BTreeMap, fmt::Formatter, marker::PhantomData};
+
 use cargo_metadata::Package;
 use petgraph::visit::Bfs;
-use std::collections::BTreeMap;
-use std::fmt::Formatter;
-use std::marker::PhantomData;
 
-/// Displays the dependencies of the project as a table, sorted by their specified MSRV.
+use crate::{
+    dependencies::{
+        formatter::{format_version, get_package_metadata_msrv, parse_manifest_workaround},
+        DependencyGraph,
+    },
+    reporter::Output,
+};
+
+/// Displays the dependencies of the project as a table, sorted by their
+/// specified MSRV.
 ///
 /// For example:
 ///
@@ -90,8 +93,7 @@ impl<T: Output> ByMSRVFormatter<T> {
 impl std::fmt::Display for ByMSRVFormatter<crate::reporter::ui::HumanPrinter<'_, '_>> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         // Table of dependencies sorted by MSRV
-        use comfy_table::presets::UTF8_FULL;
-        use comfy_table::{Cell, ContentArrangement, Table};
+        use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
 
         let out = self.dependencies_by_msrv(
             || {

--- a/src/dependencies/mod.rs
+++ b/src/dependencies/mod.rs
@@ -1,20 +1,22 @@
-use cargo_metadata::PackageId;
 use std::collections::HashMap;
+
+use cargo_metadata::PackageId;
 
 pub(crate) mod formatter;
 pub(crate) mod resolver;
 
 type PackageGraphIndex = usize;
-// NB: stable graph because we need our DependencyGraph::index to be able to bridge between id's
-//  even after removals, which we do to remove dev- and build dependencies.
+// NB: stable graph because we need our DependencyGraph::index to be able to
+// bridge between id's  even after removals, which we do to remove dev- and
+// build dependencies.
 type PackageGraph =
     petgraph::stable_graph::StableDiGraph<cargo_metadata::Package, (), PackageGraphIndex>;
 
 /// A graph of dependencies from a designated root crate
 ///
 /// Why a graph instead of simply a set of packages?
-/// To find the MSRV, all we need is the set, however, to locate where that dependency originates from,
-/// it is useful to have a graph.
+/// To find the MSRV, all we need is the set, however, to locate where that
+/// dependency originates from, it is useful to have a graph.
 #[derive(Debug)]
 pub(crate) struct DependencyGraph {
     // Useful to translate between the packages known to cargo_metadata and our petgraph.

--- a/src/dependencies/resolver.rs
+++ b/src/dependencies/resolver.rs
@@ -1,8 +1,11 @@
-use crate::config::Config;
-use crate::dependencies::DependencyGraph;
-use crate::errors::{CargoMSRVError, TResult};
-use crate::paths::crate_root_folder;
 use cargo_metadata::MetadataCommand;
+
+use crate::{
+    config::Config,
+    dependencies::DependencyGraph,
+    errors::{CargoMSRVError, TResult},
+    paths::crate_root_folder,
+};
 
 pub(crate) trait DependencyResolver {
     fn resolve(&self) -> TResult<DependencyGraph>;
@@ -49,7 +52,8 @@ impl DependencyResolver for CargoMetadataResolver {
     }
 }
 
-/// Builds a package graph from  1) a set of packages and 2) a given dependency graph.
+/// Builds a package graph from  1) a set of packages and 2) a given dependency
+/// graph.
 fn build_package_graph<Ip, Id>(graph: &mut DependencyGraph, packages: Ip, dependencies: Id)
 where
     Ip: IntoIterator<Item = cargo_metadata::Package>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,11 +1,6 @@
-use std::env;
-use std::ffi::OsString;
-use std::io;
-use std::path::PathBuf;
-use std::string::FromUtf8Error;
+use std::{env, ffi::OsString, io, path::PathBuf, string::FromUtf8Error};
 
-use crate::fetch::ToolchainSpecifier;
-use crate::manifest::bare_version::NoVersionMatchesManifestMsrvError;
+use crate::{fetch::ToolchainSpecifier, manifest::bare_version::NoVersionMatchesManifestMsrvError};
 
 pub type TResult<T> = Result<T, CargoMSRVError>;
 
@@ -74,10 +69,16 @@ pub enum CargoMSRVError {
     #[error(transparent)]
     SystemTime(#[from] std::time::SystemTimeError),
 
-    #[error("The given toolchain could not be found. Run `rustup toolchain list` for an overview of installed toolchains.")]
+    #[error(
+        "The given toolchain could not be found. Run `rustup toolchain list` for an overview of \
+         installed toolchains."
+    )]
     ToolchainNotInstalled,
 
-    #[error("The given target could not be found. Run `rustup target list` for an overview of available toolchains.")]
+    #[error(
+        "The given target could not be found. Run `rustup target list` for an overview of \
+         available toolchains."
+    )]
     UnknownTarget,
 
     #[error("Unable to access log folder, run with --no-log to try again without logging.")]
@@ -107,7 +108,10 @@ Thank you in advance!"#
     #[error("The Rust stable version could not be parsed from the stable channel manifest.")]
     UnableToParseRustVersion,
 
-    #[error("Unable to run the checking command. If --check <cmd> is specified, you could try to verify if you can run the cmd manually.")]
+    #[error(
+        "Unable to run the checking command. If --check <cmd> is specified, you could try to \
+         verify if you can run the cmd manually."
+    )]
     UnableToRunCheck,
 }
 

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,6 +1,9 @@
-use crate::command::RustupCommand;
-use crate::errors::{CargoMSRVError, TResult};
 use std::ffi::OsString;
+
+use crate::{
+    command::RustupCommand,
+    errors::{CargoMSRVError, TResult},
+};
 
 pub type ToolchainSpecifier = String;
 
@@ -29,8 +32,8 @@ pub fn is_target_available<S: AsRef<str>>(name: S) -> TResult<()> {
     Err(CargoMSRVError::UnknownTarget)
 }
 
-/// Uses the `.rustup/settings.toml` file to determine the default target (aka the
-/// `default_host_triple`) if not set by a user.
+/// Uses the `.rustup/settings.toml` file to determine the default target (aka
+/// the `default_host_triple`) if not set by a user.
 pub fn default_target() -> TResult<String> {
     let output = RustupCommand::new().with_stdout().show()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,16 +8,18 @@ use rust_releases::{
     semver, Channel, FetchResources, ReleaseIndex, RustChangelog, RustDist, Source,
 };
 
-use crate::config::{Config, ModeIntent, ReleaseSource};
-use crate::errors::{CargoMSRVError, TResult};
-use crate::reporter::{Output, ProgressAction};
-
-use crate::subcommands::list::run_list_msrv;
-use crate::subcommands::show::run_show_msrv;
+use crate::{
+    config::{Config, ModeIntent, ReleaseSource},
+    errors::{CargoMSRVError, TResult},
+    reporter::{Output, ProgressAction},
+    subcommands::{list::run_list_msrv, show::run_show_msrv},
+};
 pub use crate::{
-    result::MinimalCompatibility, subcommands::determine_msrv::determine_msrv,
-    subcommands::determine_msrv::run_determine_msrv_action,
-    subcommands::verify_msrv::run_verify_msrv_action,
+    result::MinimalCompatibility,
+    subcommands::{
+        determine_msrv::{determine_msrv, run_determine_msrv_action},
+        verify_msrv::run_verify_msrv_action,
+    },
 };
 
 pub mod check;

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -1,5 +1,7 @@
-use std::marker::PhantomData;
-use std::path::{Path, PathBuf};
+use std::{
+    marker::PhantomData,
+    path::{Path, PathBuf},
+};
 
 use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
 

--- a/src/manifest/bare_version.rs
+++ b/src/manifest/bare_version.rs
@@ -1,5 +1,7 @@
-use std::convert::TryFrom;
-use std::fmt::{Display, Formatter};
+use std::{
+    convert::TryFrom,
+    fmt::{Display, Formatter},
+};
 
 type BareVersionUsize = u64;
 
@@ -41,9 +43,10 @@ impl BareVersion {
         }
     }
 
-    // Compared to `BareVersion::to_semver_version`, this method tries to satisfy a specified semver
-    // version requirement against the given set of available version, while `BareVersion::to_semver_version`
-    // simply rewrites the versions components to their semver::Version counterpart.
+    // Compared to `BareVersion::to_semver_version`, this method tries to satisfy a
+    // specified semver version requirement against the given set of available
+    // version, while `BareVersion::to_semver_version` simply rewrites the
+    // versions components to their semver::Version counterpart.
     pub fn try_to_semver<'s, I>(
         &self,
         iter: I,
@@ -158,11 +161,11 @@ fn expect_end_of_input(input: &[u8]) -> Result<(), Error> {
     }
 }
 
-/// Parse the [`bare version`] which defines a minimal supported Rust version (MSRV or rust-version
-/// in `Cargo.toml`).
+/// Parse the [`bare version`] which defines a minimal supported Rust version
+/// (MSRV or rust-version in `Cargo.toml`).
 ///
-/// See also the [`semver 2.0 spec`], which the parser is loosely based on. NB: a `bare version` is
-/// not `semver` compatible.
+/// See also the [`semver 2.0 spec`], which the parser is loosely based on. NB:
+/// a `bare version` is not `semver` compatible.
 ///
 /// [`bare version`]: https://doc.rust-lang.org/nightly/cargo/reference/manifest.html#the-rust-version-field
 /// [`semver 2.0 spec`]: https://semver.org/spec/v2.0.0.html#backusnaur-form-grammar-for-valid-semver-versions
@@ -219,9 +222,9 @@ impl std::fmt::Display for NoVersionMatchesManifestMsrvError {
 
         write!(
             f,
-            "The MSRV requirement ({}) in the Cargo manifest did not match any available version, available: {}",
-            self.requested,
-            available,
+            "The MSRV requirement ({}) in the Cargo manifest did not match any available version, \
+             available: {}",
+            self.requested, available,
         )
     }
 }
@@ -230,10 +233,12 @@ impl std::error::Error for NoVersionMatchesManifestMsrvError {}
 
 #[cfg(test)]
 mod bare_version_tests {
-    use crate::manifest::BareVersion;
-    use rust_releases::{semver, Release, ReleaseIndex};
     use std::iter::FromIterator;
+
+    use rust_releases::{semver, Release, ReleaseIndex};
     use yare::parameterized;
+
+    use crate::manifest::BareVersion;
 
     fn release_indices() -> ReleaseIndex {
         FromIterator::from_iter(vec![

--- a/src/manifest/mod.rs
+++ b/src/manifest/mod.rs
@@ -1,6 +1,8 @@
-use crate::manifest::bare_version::BareVersion;
 use std::convert::TryFrom;
+
 use toml_edit::{Document, Item, TomlError};
+
+use crate::manifest::bare_version::BareVersion;
 
 pub(crate) mod bare_version;
 
@@ -15,7 +17,8 @@ pub trait TomlParser {
     fn parse<T: From<Document>>(&self, contents: &str) -> Result<T, Self::Error>;
 }
 
-/// A structure for owning the values in a `Cargo.toml` manifest relevant for `cargo-msrv`.
+/// A structure for owning the values in a `Cargo.toml` manifest relevant for
+/// `cargo-msrv`.
 #[derive(Debug)]
 pub struct CargoManifest {
     minimum_rust_version: Option<BareVersion>,
@@ -27,7 +30,8 @@ impl CargoManifest {
     }
 }
 
-/// A parser for `Cargo.toml` files. Only handles the parts necessary for `cargo-msrv`.
+/// A parser for `Cargo.toml` files. Only handles the parts necessary for
+/// `cargo-msrv`.
 #[derive(Debug)]
 pub struct CargoManifestParser;
 
@@ -73,7 +77,8 @@ fn minimum_rust_version(value: &Document) -> Result<Option<BareVersion>, crate::
     Ok(Some(BareVersion::try_parse(version)?))
 }
 
-/// Parse the minimum supported Rust version (MSRV) from `Cargo.toml` manifest data.
+/// Parse the minimum supported Rust version (MSRV) from `Cargo.toml` manifest
+/// data.
 fn find_minimum_rust_version(document: &Document) -> Option<&str> {
     /// Parses the `MSRV` as supported by Cargo since Rust 1.56.0
     ///
@@ -87,8 +92,8 @@ fn find_minimum_rust_version(document: &Document) -> Option<&str> {
             .and_then(Item::as_str)
     }
 
-    /// Parses the MSRV as supported by `cargo-msrv`, since prior to the release of Rust
-    /// 1.56.0
+    /// Parses the MSRV as supported by `cargo-msrv`, since prior to the release
+    /// of Rust 1.56.0
     fn find_metadata_msrv(document: &Document) -> Option<&str> {
         document
             .as_table()
@@ -107,11 +112,16 @@ fn find_minimum_rust_version(document: &Document) -> Option<&str> {
 
 #[cfg(test)]
 mod minimal_version_tests {
-    use crate::errors::CargoMSRVError;
-    use crate::manifest::bare_version::Error;
-    use crate::manifest::{BareVersion, CargoManifest, CargoManifestParser, TomlParser};
     use std::convert::TryFrom;
+
     use toml_edit::Document;
+
+    use crate::{
+        errors::CargoMSRVError,
+        manifest::{
+            bare_version::Error, BareVersion, CargoManifest, CargoManifestParser, TomlParser,
+        },
+    };
 
     #[test]
     fn parse_toml() {
@@ -123,9 +133,11 @@ edition = "2018"
 [dependencies]
 "#;
 
-        assert!(CargoManifestParser::default()
-            .parse::<Document>(contents)
-            .is_ok());
+        assert!(
+            CargoManifestParser::default()
+                .parse::<Document>(contents)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -138,9 +150,11 @@ edition = "2018"
 [dependencies]
 "#;
 
-        assert!(CargoManifestParser::default()
-            .parse::<Document>(contents)
-            .is_err());
+        assert!(
+            CargoManifestParser::default()
+                .parse::<Document>(contents)
+                .is_err()
+        );
     }
 
     #[test]
@@ -345,10 +359,12 @@ msrv = "{}"
 
 #[cfg(test)]
 mod bare_version_tests {
-    use crate::manifest::BareVersion;
-    use rust_releases::{semver, Release, ReleaseIndex};
     use std::iter::FromIterator;
+
+    use rust_releases::{semver, Release, ReleaseIndex};
     use yare::parameterized;
+
+    use crate::manifest::BareVersion;
 
     fn release_indices() -> ReleaseIndex {
         FromIterator::from_iter(vec![

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
-use crate::config::Config;
-use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
+use crate::{
+    config::Config,
+    errors::{CargoMSRVError, IoErrorSource, TResult},
+};
 
 pub fn crate_root_folder(config: &Config) -> TResult<PathBuf> {
     if let Some(path) = config.crate_path() {

--- a/src/reporter/json.rs
+++ b/src/reporter/json.rs
@@ -3,8 +3,7 @@ use std::cell::Cell;
 use json::{number::Number, object, JsonValue};
 use rust_releases::semver;
 
-use crate::config::ModeIntent;
-use crate::reporter::ProgressAction;
+use crate::{config::ModeIntent, reporter::ProgressAction};
 
 #[derive(Debug)]
 pub struct JsonPrinter<'s, 't> {

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -32,13 +32,14 @@ pub trait Output: Debug {
 }
 
 pub mod __private {
-    use std::cell::RefCell;
-    use std::rc::Rc;
+    use std::{cell::RefCell, rc::Rc};
 
     use rust_releases::semver;
 
-    use crate::config::ModeIntent;
-    use crate::reporter::{Output, ProgressAction};
+    use crate::{
+        config::ModeIntent,
+        reporter::{Output, ProgressAction},
+    };
 
     /// This is meant to be used for testing
     #[derive(Debug)]
@@ -54,14 +55,20 @@ pub mod __private {
 
     impl Output for SuccessOutput {
         fn mode(&self, _action: ModeIntent) {}
+
         fn set_steps(&self, _steps: u64) {}
+
         fn progress(&self, _action: ProgressAction) {}
+
         fn complete_step(&self, version: &semver::Version, success: bool) {
             let mut successes = self.successes.borrow_mut();
             successes.push((success, version.clone()));
         }
+
         fn finish_success(&self, _mode: ModeIntent, _version: Option<&semver::Version>) {}
+
         fn finish_failure(&self, _mode: ModeIntent, _cmd: Option<&str>) {}
+
         fn write_line(&self, _content: &str) {}
     }
 

--- a/src/reporter/no_output.rs
+++ b/src/reporter/no_output.rs
@@ -5,10 +5,16 @@ pub struct NoOutput;
 
 impl Output for NoOutput {
     fn mode(&self, _action: ModeIntent) {}
+
     fn set_steps(&self, _steps: u64) {}
+
     fn progress(&self, _action: ProgressAction) {}
+
     fn complete_step(&self, _version: &semver::Version, _success: bool) {}
+
     fn finish_success(&self, _mode: ModeIntent, _version: Option<&semver::Version>) {}
+
     fn finish_failure(&self, _mode: ModeIntent, _cmd: Option<&str>) {}
+
     fn write_line(&self, _content: &str) {}
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,14 +5,16 @@ use crate::check::Outcome;
 /// An enum to represent the minimal compatibility
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum MinimalCompatibility {
-    /// A toolchain is compatible, if the outcome of a toolchain check results in a success
+    /// A toolchain is compatible, if the outcome of a toolchain check results
+    /// in a success
     CapableToolchain {
         // toolchain specifier
         toolchain: String,
         // checked Rust version
         version: semver::Version,
     },
-    /// Compatibility is none, if the check on the last available toolchain fails
+    /// Compatibility is none, if the check on the last available toolchain
+    /// fails
     NoCompatibleToolchains,
 }
 

--- a/src/subcommands/determine_msrv.rs
+++ b/src/subcommands/determine_msrv.rs
@@ -1,12 +1,13 @@
-use rust_releases::linear::LatestStableReleases;
-use rust_releases::{semver, Release, ReleaseIndex};
+use rust_releases::{linear::LatestStableReleases, semver, Release, ReleaseIndex};
 
-use crate::check::{as_toolchain_specifier, check_toolchain};
-use crate::config::{Config, ModeIntent};
-use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
-use crate::paths::crate_root_folder;
-use crate::reporter::{Output, ProgressAction};
-use crate::result::MinimalCompatibility;
+use crate::{
+    check::{as_toolchain_specifier, check_toolchain},
+    config::{Config, ModeIntent},
+    errors::{CargoMSRVError, IoErrorSource, TResult},
+    paths::crate_root_folder,
+    reporter::{Output, ProgressAction},
+    result::MinimalCompatibility,
+};
 
 pub fn run_determine_msrv_action<R: Output>(
     config: &Config,

--- a/src/subcommands/list.rs
+++ b/src/subcommands/list.rs
@@ -1,8 +1,9 @@
-use crate::config::list::ListVariant;
-use crate::config::{Config, ModeIntent, OutputFormat};
-use crate::dependencies::resolver::{CargoMetadataResolver, DependencyResolver};
-use crate::errors::TResult;
-use crate::reporter::Output;
+use crate::{
+    config::{list::ListVariant, Config, ModeIntent, OutputFormat},
+    dependencies::resolver::{CargoMetadataResolver, DependencyResolver},
+    errors::TResult,
+    reporter::Output,
+};
 
 pub fn run_list_msrv<R: Output>(config: &Config, output: &R) -> TResult<()> {
     use crate::dependencies::formatter;

--- a/src/subcommands/show.rs
+++ b/src/subcommands/show.rs
@@ -1,11 +1,14 @@
-use crate::config::{Config, ModeIntent};
-use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
-use crate::manifest::bare_version::BareVersion;
-use crate::manifest::{CargoManifest, CargoManifestParser, TomlParser};
-use crate::paths::crate_root_folder;
-use crate::reporter::Output;
 use std::convert::TryFrom;
+
 use toml_edit::Document;
+
+use crate::{
+    config::{Config, ModeIntent},
+    errors::{CargoMSRVError, IoErrorSource, TResult},
+    manifest::{bare_version::BareVersion, CargoManifest, CargoManifestParser, TomlParser},
+    paths::crate_root_folder,
+    reporter::Output,
+};
 
 pub fn run_show_msrv<R: Output>(config: &Config, output: &R) -> TResult<()> {
     output.mode(ModeIntent::Show);

--- a/src/subcommands/verify_msrv.rs
+++ b/src/subcommands/verify_msrv.rs
@@ -3,12 +3,14 @@ use std::convert::TryFrom;
 use rust_releases::{Release, ReleaseIndex};
 use toml_edit::Document;
 
-use crate::check::{check_toolchain, Outcome};
-use crate::config::{Config, ModeIntent};
-use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
-use crate::manifest::{CargoManifest, CargoManifestParser, TomlParser};
-use crate::paths::crate_root_folder;
-use crate::reporter::Output;
+use crate::{
+    check::{check_toolchain, Outcome},
+    config::{Config, ModeIntent},
+    errors::{CargoMSRVError, IoErrorSource, TResult},
+    manifest::{CargoManifest, CargoManifestParser, TomlParser},
+    paths::crate_root_folder,
+    reporter::Output,
+};
 
 // NB: only public for integration testing
 pub fn run_verify_msrv_action<R: Output>(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,19 +1,17 @@
 #![allow(unused)] // allowed since we do use these functions in the actual test files
 
-use std::ffi::OsString;
-use std::iter::FromIterator;
+use std::{ffi::OsString, iter::FromIterator};
 
-use rust_releases::semver::Version;
-use rust_releases::{semver, Release, ReleaseIndex};
-
-use cargo_msrv::config::{test_config_from_matches, Config, OutputFormat};
-use cargo_msrv::errors::TResult;
-use cargo_msrv::reporter::__private::SuccessOutput;
-use cargo_msrv::reporter::json::JsonPrinter;
-use cargo_msrv::reporter::no_output::NoOutput;
-use cargo_msrv::reporter::ui::HumanPrinter;
-use cargo_msrv::reporter::Output;
-use cargo_msrv::{reporter, MinimalCompatibility};
+use cargo_msrv::{
+    config::{test_config_from_matches, Config, OutputFormat},
+    errors::TResult,
+    reporter,
+    reporter::{
+        __private::SuccessOutput, json::JsonPrinter, no_output::NoOutput, ui::HumanPrinter, Output,
+    },
+    MinimalCompatibility,
+};
+use rust_releases::{semver, semver::Version, Release, ReleaseIndex};
 
 pub fn run_msrv<I: IntoIterator<Item = T>, T: Into<OsString> + Clone>(
     with_args: I,
@@ -77,8 +75,8 @@ where
     let matches = cargo_msrv::cli::cli().get_matches_from(with_args);
     let config = test_config_from_matches(&matches).expect("Unable to parse cli arguments");
 
-    // Limit the available versions: this ensures we don't need to incrementally install more toolchains
-    //  as more Rust toolchains become available.
+    // Limit the available versions: this ensures we don't need to incrementally
+    // install more toolchains  as more Rust toolchains become available.
     let available_versions: ReleaseIndex = FromIterator::from_iter(releases);
 
     // Determine the MSRV from the index of available releases.
@@ -96,8 +94,8 @@ pub fn run_cargo_version_which_doesnt_support_lockfile_v2<
 
     let reporter = fake_reporter();
 
-    // Limit the available versions: this ensures we don't want to incrementally install more toolchains
-    //  as more Rust toolchains become available.
+    // Limit the available versions: this ensures we don't want to incrementally
+    // install more toolchains  as more Rust toolchains become available.
     let available_versions: ReleaseIndex = FromIterator::from_iter(vec![
         Release::new_stable(semver::Version::new(1, 39, 0)),
         Release::new_stable(semver::Version::new(1, 38, 0)),

--- a/tests/find_msrv.rs
+++ b/tests/find_msrv.rs
@@ -1,12 +1,11 @@
 extern crate cargo_msrv;
 
-use parameterized::parameterized;
-use rust_releases::{semver, Release};
-
 use cargo_msrv::MinimalCompatibility;
 use common::{
     run_cargo_version_which_doesnt_support_lockfile_v2, run_msrv, run_msrv_with_releases,
 };
+use parameterized::parameterized;
+use rust_releases::{semver, Release};
 
 mod common;
 

--- a/tests/verify_msrv.rs
+++ b/tests/verify_msrv.rs
@@ -1,7 +1,6 @@
+use common::run_verify;
 use parameterized::parameterized;
 use rust_releases::{semver, Release};
-
-use common::run_verify;
 
 mod common;
 


### PR DESCRIPTION
adds additional rustfmt config and applies it to the codebase.

let me know what you think about the individual config options. I know import sorting/grouping is a matter of personal taste. I think the rest should be fairly uncontroversial