### PR TITLE
Prefer the cargo standard 'package.rust-version' when msrv is undefined in the Cargo manifest

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -47,7 +47,7 @@ pub enum CargoMSRVError {
     #[error(transparent)]
     NoVersionMatchesManifestMSRV(#[from] NoVersionMatchesManifestMsrvError),
 
-    #[error("Unable to find key 'package.metadata.msrv' in '{0}'")]
+    #[error("Unable to find key 'package.rust-version' (or 'package.metadata.msrv') in '{0}'")]
     NoMSRVKeyInCargoToml(PathBuf),
 
     #[error("Unable to parse Cargo.toml: {0}")]


### PR DESCRIPTION
…