### PR TITLE
Cache Rust toolchains on the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,12 @@ jobs:
       - name: test_all
         run: cargo test --verbose --all -- --test-threads=1
 
+      # show installed toolchains
+      - name: show_installed_toolchains
+        run: |
+          ls ~/.rustup/toolchains
+          ls ~/.rustup/toolchains/*.*.* 
+
       # setup Rust toolchain cache
       - name: cache_rustup
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,15 @@ jobs:
       - name: checkout_repository
         uses: actions/checkout@v2.4.0
 
+      # setup Rust toolchain cache
+      - name: cache_rustup
+        uses: actions/cache@v2
+        with:
+          # only match numbered versions, i.e. exclude rolling stable/beta/nightly toolchains as they change between releases
+          path: |
+            ~/.rustup/toolchains/*.*.*
+          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('**/rustc*') }}
+
       # install: rust
       - name: install_rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,6 @@ jobs:
       - name: checkout_repository
         uses: actions/checkout@v2.4.0
 
-      # setup Rust toolchain cache
-      - name: cache_rustup
-        uses: actions/cache@v2
-        with:
-          # only match numbered versions, i.e. exclude rolling stable/beta/nightly toolchains as they change between releases
-          path: |
-            ~/.rustup/toolchains/*.*.*
-          key: ${{ runner.os }}-rust-toolchain-${{ hashFiles('**/rustc*') }}
 
       # install: rust
       - name: install_rust
@@ -87,6 +79,16 @@ jobs:
 
       - name: test_all
         run: cargo test --verbose --all -- --test-threads=1
+
+      # setup Rust toolchain cache
+      - name: cache_rustup
+        uses: actions/cache@v2
+        with:
+          # only match numbered versions, i.e. exclude rolling stable/beta/nightly toolchains as they change between releases
+          path: |
+            ~/.rustup/toolchains/*.*.*
+          key: |
+            ${{ runner.os }}-rust-toolchain-${{ hashFiles('**/rustc*') }}
 
   rustfmt:
     name: rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,15 @@ jobs:
       - name: checkout_repository
         uses: actions/checkout@v2.4.0
 
+      - name: cache_rustup
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.rustup/toolchains
+          key: |
+            ${{ runner.os }}-rust-toolchain-${{ hashFiles('**/rustc*') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-toolchain-
 
       # install: rust
       - name: install_rust
@@ -72,17 +81,6 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           profile: minimal
-
-      - name: cache_rustup
-        uses: actions/cache@v2
-        with:
-          # only match numbered versions, i.e. exclude rolling stable/beta/nightly toolchains as they change between releases
-          path: |
-            ~/.rustup/toolchains/*.*.*
-          key: |
-            ${{ runner.os }}-rust-toolchain-${{ hashFiles('**/rustc*') }}
-          restore-keys: |
-            ${{ runner.os }}-rust-toolchain-
 
       # build / doc / test
       - name: build_all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,20 +73,6 @@ jobs:
           override: true
           profile: minimal
 
-      # build / doc / test
-      - name: build_all
-        run: cargo build --verbose --all
-
-      - name: test_all
-        run: cargo test --verbose --all -- --test-threads=1
-
-      # show installed toolchains
-      - name: show_installed_toolchains
-        run: |
-          ls ~/.rustup/toolchains
-          ls ~/.rustup/toolchains/*.*.* 
-
-      # setup Rust toolchain cache
       - name: cache_rustup
         uses: actions/cache@v2
         with:
@@ -95,6 +81,24 @@ jobs:
             ~/.rustup/toolchains/*.*.*
           key: |
             ${{ runner.os }}-rust-toolchain-${{ hashFiles('**/rustc*') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-toolchain-
+
+      # build / doc / test
+      - name: build_all
+        run: cargo build --verbose --all
+
+      - name: test_all
+        run: cargo test --verbose --all -- --test-threads=1
+
+      # show installed toolchains
+      - name: show_installed_toolchains_all
+        run: |
+          ls ~/.rustup/toolchains
+
+      - name: show_installed_toolchains_versioned
+        run: |
+          ls ~/.rustup/toolchains/*.*.* 
 
   rustfmt:
     name: rustfmt


### PR DESCRIPTION
We download several Rust toolchains on the CI, used by our test suite. Downloading toolchains takes significant time, and bandwidth, which we try to save by caching the toolchains.

The cached folders must match a numbered toolchain as the rolling, unspecified beyond the channel, toolchain versions (e.g. 'stable-x86_64-pc-windows-gnu') change on every release.

The hash key determining cache eviction is a combination of the OS, and rustc* files in the target cache folder. Possibly the ~/.rustup/update-hashes/<toolchain-download-hash> could be used if this doesn't work, but requires more setup work (i.e. matching the cache folder path name to the file names in ~/.rustup/update-hashes/, and then taking the respective hash from the matching update-hashes file), but I wasn't sure how to access the "currently considered" path, altough I might be approaching the problem from the wrong angle.