### PR TITLE
Use subcommand verify on the ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,6 @@ jobs:
       - name: install_jsonlines
         run: cargo install jsonlines
       - name: version_of_cargo_msrv
-        run: cargo msrv --version # as of writing: 0.7.0 (required for --verify)
+        run: cargo msrv --version # as of writing: 0.14.0 (required for verify)
       - name: run_cargo_msrv
-        run: cargo msrv --verify --output-format json | jsonlines-tail | jq --exit-status .success
+        run: cargo msrv verify --output-format json | jsonlines-tail | jq --exit-status .success


### PR DESCRIPTION
Previously used `cargo msrv --verify`. Since cargo-msrv v0.14.0, this flag is deprecated in favour of the new `cargo msrv verify` subcommand.