### PR TITLE
Update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ With Cargo from Github [latest development version]:
 
 `cargo install cargo-msrv --git https://github.com/foresterre/cargo-msrv.git --branch main`
 
-From the [AUR](https://aur.archlinux.org/packages/cargo-msrv/) (Arch Linux):
+From the Arch Linux [community repository](https://archlinux.org/packages/community/x86_64/cargo-msrv/):
 
-`paru -S cargo-msrv`
+`pacman -S cargo-msrv`
 
 ### Preview
 


### PR DESCRIPTION
`cargo-msrv` is now moved to Arch Linux community repository, meaning that it can be installed with `pacman`:

- https://archlinux.org/packages/community/x86_64/cargo-msrv/ 

This PR updates README.md to reflect these changes.

