### PR TITLE
Fix verify subcommand would not allow a custom check command to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 
 [unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.14.1...HEAD
 
+* Fixed: Unable to set a custom check command when calling the cargo-msrv verify subcommand.
+
 # [0.14.1] - 2022-02-02
 
-* Fixed: Regression in the new bisection implementation introduced in v0.14.0, where the alogithm would stop one step too early.
+* Fixed: Regression in the new bisection implementation introduced in v0.14.0, where the algorithm would stop one step too early.
 
 [0.14.1]: https://github.com/foresterre/cargo-msrv/compare/v0.14.0...v0.14.1
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -185,17 +185,22 @@ rustup like so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provi
             .help("If provided, the outcome of each individual check will not be printed.")
             .takes_value(false)
         )
-        .arg(
-            Arg::new(id::ARG_CUSTOM_CHECK)
-                .value_name("COMMAND")
-                .help("If given, this command is used to validate if a Rust version is \
+        .arg(custom_check())
+}
+
+pub fn custom_check() -> Arg<'static> {
+    Arg::new(id::ARG_CUSTOM_CHECK)
+        .value_name("COMMAND")
+        .help(
+            "If given, this command is used to validate if a Rust version is \
                 compatible. Should be available to rustup, i.e. the command should work like \
                 so: `rustup run <toolchain> <COMMAND>`. \
-                The default check action is `cargo check --all`.")
-                .multiple_values(true)
-                .last(true)
-
+                The default check action is `cargo check --all`.",
         )
+        .multiple_values(true)
+        .takes_value(true)
+        .required(false)
+        .last(true)
 }
 
 pub fn list() -> App<'static> {
@@ -220,6 +225,7 @@ pub fn show() -> App<'static> {
 pub fn verify() -> App<'static> {
     App::new(id::SUB_COMMAND_VERIFY)
         .about("Verify whether the MSRV is satisfiable. The MSRV must be specified using the 'package.rust-version' or 'package.metadata.msrv' key in the Cargo.toml manifest.")
+        .arg(custom_check())
 }
 
 #[cfg(test)]

--- a/tests/verify_msrv.rs
+++ b/tests/verify_msrv.rs
@@ -126,3 +126,35 @@ fn verify_failure_non_zero_exit_code(verify_variant: &str) {
 
     assert_eq!(exit_code, Into::<i32>::into(expected))
 }
+
+#[test]
+fn verify_subcommand_success_with_custom_check_cmd() {
+    let cargo_msrv_dir = env!("CARGO_MANIFEST_DIR");
+    let cargo_msrv_manifest = [cargo_msrv_dir, "Cargo.toml"].join("/");
+    let test_subject = [cargo_msrv_dir, "tests", "fixtures", "1.56.0-edition-2021"].join("/");
+
+    let mut process = Command::new("cargo")
+        .args(&[
+            "run",
+            "--manifest-path",
+            &cargo_msrv_manifest,
+            "--",
+            "--path",
+            &test_subject,
+            "verify",
+            "--",
+            "cargo",
+            "build",
+        ])
+        .spawn()
+        .expect("Unable to spawn cargo-msrv via cargo in test");
+
+    let exit_status = process
+        .wait()
+        .expect("Waiting for process failed during test");
+
+    let exit_code = exit_status.code().unwrap();
+    let expected = ExitCode::Success;
+
+    assert_eq!(exit_code, Into::<i32>::into(expected))
+}


### PR DESCRIPTION
Prior to adding verify as a subcommand, and the deprecation of the --verify flag, the custom check command would be matched by the arg matcher of the root command. Now that verify has been added as its own subcommand, the custom check command does not seem to be inherited from the root command. This was fixed by defining the custom check command on the verify subcommand in addition to the root command.

closes #296