### PR TITLE
Change default check command to `cargo check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 This is the changelog for [cargo-msrv](https://github.com/foresterre/cargo-msrv), a tool and cargo plugin, which can be
 used to find the Minimum Supported Rust Version (MSRV) of your projects.
 This changelog is aimed at users, and only contains user-relevant changes.
@@ -5,23 +7,29 @@ This changelog is aimed at users, and only contains user-relevant changes.
 If you found an issue, have a suggestion or want to provide feedback or insights, please feel free to open an issue on
 the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a topic in the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 
-# [unreleased]
+## [Unreleased]
 
-[unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.14.2...HEAD
+### Changed
 
-# [0.14.2] - 2022-02-09
+* ⚠️ Breaking change: Changed default cargo-msrv (find) check command from `cargo check --all` to `cargo check`
+  * Revert to the old behaviour by running cargo-msrv with a custom check command: `cargo msrv -- cargo check --all`.
 
-[0.14.2]: https://github.com/foresterre/cargo-msrv/compare/v0.14.1...v0.14.2
+[Unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.14.2...HEAD
+
+
+## [0.14.2] - 2022-02-09
 
 * Fixed: Unable to set a custom check command when calling the cargo-msrv verify subcommand.
 
-# [0.14.1] - 2022-02-02
+[0.14.2]: https://github.com/foresterre/cargo-msrv/compare/v0.14.1...v0.14.2
+
+## [0.14.1] - 2022-02-02
 
 * Fixed: Regression in the new bisection implementation introduced in v0.14.0, where the algorithm would stop one step too early.
 
 [0.14.1]: https://github.com/foresterre/cargo-msrv/compare/v0.14.0...v0.14.1
 
-# [0.14.0] - 2022-01-30
+## [0.14.0] - 2022-01-30
 
 * Added: Verify as a subcommand
 * Deprecated: Deprecated the `cargo msrv --verify` flag in favour of the `cargo msrv verify` subcommand.
@@ -34,7 +42,7 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 
 [0.14.0]: https://github.com/foresterre/cargo-msrv/compare/v0.13.0...v0.14.0
 
-# [0.13.0] - 2021-12-25
+## [0.13.0] - 2021-12-25
 
 * Fixed: Help text of the list subcommand will now be shown correctly .  
 * Fixed: The json output of the list subcommand will now also report when it's done.
@@ -50,7 +58,7 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 
 [0.13.0]: https://github.com/foresterre/cargo-msrv/compare/v0.12.0...v0.13.0
 
-# [0.12.0] - 2021-11-01
+## [0.12.0] - 2021-11-01
 
 * Added subcommand `list` which lists the MSRV's of dependencies as specified by crate authors using the rust-version key.
 * You can now also simply run cargo-msrv standalone, i.e. `cargo-msrv` instead of `cargo msrv`.
@@ -60,13 +68,13 @@ but are planned to._
 
 [0.12.0]: https://github.com/foresterre/cargo-msrv/compare/v0.11.1...v0.12.0
 
-# [0.11.1] - 2021-10-28
+## [0.11.1] - 2021-10-28
 
 This release is equal to `v0.11.0`, except that the automated 'release build and packaging' task was fixed.  
 
 [0.11.1]: https://github.com/foresterre/cargo-msrv/compare/v0.11.0...v0.11.1
 
-# [0.11.0] - 2021-10-28
+## [0.11.0] - 2021-10-28
 
 * Added `--release-source` which allows users to select a rust-releases source.
 * A message is now shown to inform users when the index is being updated.
@@ -76,7 +84,7 @@ This behaviour can be disabled by providing the `--no-read-min-edition` flag.
 
 [0.11.0]: https://github.com/foresterre/cargo-msrv/compare/v0.10.0...v0.11.0
 
-# [0.10.0] - 2021-10-01
+## [0.10.0] - 2021-10-01
 
 * Add option to specify an edition alias instead of a minimum version.
 
@@ -88,32 +96,32 @@ This behaviour can be disabled by providing the `--no-read-min-edition` flag.
 
 [0.9.0]: https://github.com/foresterre/cargo-msrv/compare/v0.8.0...v0.9.0
 
-# [0.8.0] - 2021-07-30
+## [0.8.0] - 2021-07-30
 
 * Renamed `--minimum` to `--min` while keeping the former as an alias.
 * Renamed `--maximum` to `--max` while keeping the former as an alias.
 
 [0.8.0]: https://github.com/foresterre/cargo-msrv/compare/v0.7.0...v0.8.0
 
-# [0.7.0] - 2021-06-15
+## [0.7.0] - 2021-06-15
 
 * Added command (`--verify`) to verify the MSRV, if defined with the 'package.metadata.msrv' key in the `Cargo.toml`.
 
 [0.7.0]: https://github.com/foresterre/cargo-msrv/compare/v0.6.0...v0.7.0
 
-# [0.6.0] - 2021-05-27
+## [0.6.0] - 2021-05-27
 
 * Added option,`--output-format`, to output the status of the program in a machine-readable format to stdout.
 
 [0.6.0]: https://github.com/foresterre/cargo-msrv/compare/v0.5.0...v0.6.0
 
-# [0.5.0] - 2021-05-13
+## [0.5.0] - 2021-05-13
 
 * Added flag `--ignore-lockfile` which addresses an issue where newer lockfiles could not be parsed by older toolchains.
 
 [0.5.0]: https://github.com/foresterre/cargo-msrv/compare/v0.4.0...v0.5.0
 
-# [0.4.0] - 2021-04-09
+## [0.4.0] - 2021-04-09
 
 * Added option to only take the latest patch Release version into acount, and make it the default.
 * Added minimum and maximum release version options, which can be used to restrict the range of version to be checked.
@@ -123,28 +131,28 @@ This behaviour can be disabled by providing the `--no-read-min-edition` flag.
 
 [0.4.0]: https://github.com/foresterre/cargo-msrv/compare/v0.3.1...v0.4.0
 
-# [0.3.1] - 2021-03-09
+## [0.3.1] - 2021-03-09
 
 * Update deprecated dependency.
 * Add repository to `Cargo.toml`.
 
 [0.3.1]: https://github.com/foresterre/cargo-msrv/compare/v0.3.0...v0.3.1
 
-# [0.3.0] - 2021-03-09
+## [0.3.0] - 2021-03-09
 
 * Replace guessing Rust release version numbers with fetching an actual index.
 * Make the terminal UI friendlier by replacing the log and wall of text with a progress bar and updating state.
 
 [0.3.0]: https://github.com/foresterre/cargo-msrv/compare/v0.2.1...v0.3.0
 
-# [0.2.1]
+## [0.2.1]
 
 * Fix bug where no output was shown to the user by default.
 * Increased own crate MSRV from `1.40.0` to `1.42.0`.
 
 [0.2.1]: https://github.com/foresterre/cargo-msrv/compare/v0.2.0...v0.2.1
 
-# [0.2.0]
+## [0.2.0]
 
 * Replace `reqwest` http client with a smaller http client.
 * Inform a user about sub-tasks such as installing a toolchain or running a check.
@@ -154,7 +162,7 @@ This behaviour can be disabled by providing the `--no-read-min-edition` flag.
 
 [0.2.0]: https://github.com/foresterre/cargo-msrv/compare/v0.1.0...v0.2.0
 
-# [0.1.0]
+## [0.1.0]
 
 * Rust release channel manifest will now be re-fetched (expiry date of 1 day)
 * Added support for custom rustup run commands; defaults to `cargo build --all`.
@@ -163,7 +171,7 @@ This behaviour can be disabled by providing the `--no-read-min-edition` flag.
 
 [0.1.0]: https://github.com/foresterre/cargo-msrv/compare/v0.0.0...v0.1.0
 
-# [0.0.0]
+## [0.0.0]
 
 * This was the initial `cargo-msrv` release.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -195,7 +195,7 @@ pub fn custom_check() -> Arg<'static> {
             "If given, this command is used to validate if a Rust version is \
                 compatible. Should be available to rustup, i.e. the command should work like \
                 so: `rustup run <toolchain> <COMMAND>`. \
-                The default check action is `cargo check --all`.",
+                The default check action is `cargo check`.",
         )
         .multiple_values(true)
         .takes_value(true)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -145,7 +145,7 @@ impl<'a> Config<'a> {
         Self {
             mode_intent,
             target,
-            check_command: vec!["cargo", "check", "--all"],
+            check_command: vec!["cargo", "check"],
             crate_path: None,
             include_all_patch_releases: false,
             minimum_version: None,

--- a/tests/fixtures/virtual-workspace/.gitignore
+++ b/tests/fixtures/virtual-workspace/.gitignore
@@ -1,0 +1,2 @@
+*.lock
+/target

--- a/tests/fixtures/virtual-workspace/Cargo.toml
+++ b/tests/fixtures/virtual-workspace/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = [ "a", "b"]

--- a/tests/fixtures/virtual-workspace/a/Cargo.toml
+++ b/tests/fixtures/virtual-workspace/a/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "a"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.56"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/fixtures/virtual-workspace/a/src/lib.rs
+++ b/tests/fixtures/virtual-workspace/a/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn hello_from_a(name: &str) -> String {
+	format!("Hello {}, I'm A", name)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::hello_from_a;
+
+    #[test]
+    fn a_works() {
+        let result = hello_from_a("Christopher");
+        assert_eq!(result.as_str(), "Hello Christopher, I'm A");
+    }
+}

--- a/tests/fixtures/virtual-workspace/b/Cargo.toml
+++ b/tests/fixtures/virtual-workspace/b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "b"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.58"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/fixtures/virtual-workspace/b/src/lib.rs
+++ b/tests/fixtures/virtual-workspace/b/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn hello_from_b(name: &str) -> String {
+	format!("Hello {}, I'm B", name)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::hello_from_b;
+
+    #[test]
+    fn b_works() {
+        let result = hello_from_b("Christopher");
+        assert_eq!(result.as_str(), "Hello Christopher, I'm B");
+    }
+}

--- a/tests/fixtures/virtual-workspace/description.md
+++ b/tests/fixtures/virtual-workspace/description.md
@@ -1,0 +1,11 @@
+The `virtual-workspace` fixture consists of a virtual workspace, and two packages within the virtual workspace named 'a'
+and `b`. The package `a` has a defined `rust-version` of `1.56` and package `b` has a defined `rust-version` of `1.58`.
+
+When determining the MSRV for package `a` in the workspace, e.g. by running `cargo msrv --path a` (with default check
+command `cargo check`), it should find an MSRV of `1.56`, while running `cargo msrv --path b` should return an MSRV of
+`1.58`.
+
+Prior to cargo-msrv 0.15.0, the default check command was `cargo check --all`. This would instead always find the
+greatest common MSRV of the workspace, regardless of which package we were in. We can simulate this behaviour by
+running `cargo msrv -- cargo check --all`. The result of this command instead should be an MSRV of `1.58`, as package
+`b` is the greatest common MSRV in the workspace.


### PR DESCRIPTION
Previously, the default check command was `cargo check --all`.
This worked if you wanted to find the MSRV of the greatest common MSRV of all packages in the workspace. However, if you want to find the MSRV of the current package (whether it's a virtual workspace, workspace root, or regular package), finding the greatest common MSRV is not the goal of the search for the MSRV. Instead, you'll want to define the MSRV for the smallest logical unit. In this case, when a package depends on workspace packages (or external packages), it's MSRV will already be dependent on these packages with the regular `cargo check` command. As such it makes sense to change the default to be just `cargo check`.

To revert to the old behaviour, you can run cargo-msrv with `cargo msrv -- cargo check --all`.

BREAKING CHANGE: Changed default cargo-msrv (find) check command from `cargo check --all` to `cargo check`

---

closes #297 