### PR TITLE
Remove `--output-format void` in favour of a `--no-user-output` flag for a more consistent CLI experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 
 ## [Unreleased]
 
+### Added
+
+* Flag `--no-user-output` which disables user output.
+
 ### Changed
 
-* ⚠️ Breaking change: Changed default cargo-msrv (find) check command from `cargo check --all` to `cargo check`
+* ⚠️ Breaking change: Changed default cargo-msrv (find) check command from `cargo check --all` to `cargo check`.
   * Revert to the old behaviour by running cargo-msrv with a custom check command: `cargo msrv -- cargo check --all`.
+
+### Removed
+
+* ⚠️ Breaking change: Value `void` was removed as a valid format for the `--output-format` option.
 
 [Unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.14.2...HEAD
 

--- a/book/src/commands/find.md
+++ b/book/src/commands/find.md
@@ -84,11 +84,10 @@ When `--no-log` is present, this option will be ignored.
 
 **`--log-target` log_target**
 
-Specify where cargo-msrv should output its debug logs.
+Specify where cargo-msrv should output its internal debug logs.
 Possible values are `file` (default) and `stdout`.
-The log output of `stdout` may interfere with user output. We would suggest to use `--output-format void` in tandem
-with `--log-target stdout`.
-When `--no-log` is present, this option will be ignored.
+The log output of `stdout` may interfere with user output. We would suggest to use `--no-user-output` in tandem
+with `--log-target stdout`. When `--no-log` is present, this option will be ignored.
 
 
 **`--max` version**
@@ -112,7 +111,7 @@ incompatible, for example, so you can identify Rust features which require a cer
 
 **`--no-log`**
 
-Do not write debug log output to the log target.
+Do not write (internal) debug log output to the log target.
 
 
 **`--no-read-min-edition`**
@@ -121,11 +120,18 @@ If provided, the 'package.edition' value in the Cargo.toml will not be used to r
 By default, the edition is read from the `Cargo.toml` file and used as the minimum Rust version. See also `--min`.
 
 
+**`--no-user-output`**
+
+Disables printing of diagnostic status messages. Useful when internal log output messages are printed to the stdout,
+using `--log-target stdout`, so no clipping between the user output prints and log message prints will take place.
+When present, the `--output-format [value]` option will be ignored.
+
 **`--output-format` format**
 
-Output status messages in machine-readable format. Machine-readable status updates will be printed in the requested format to stdout.
-Accepted formats are "json" and "void". In case of "json", JSON output will be written; and in case of "void", no output
-will be written. If this option is absent, a human-readable output format will be shown.  
+Output diagnostic status messages in machine-readable format. Machine-readable status updates will be printed in the
+requested format to stdout. The only accepted format is currently "json", which will print diagnostic messages in a JSON
+format. When this option is absent, human-readable output will be printed. Diagnostic messages can be disabled entirely
+using the `--no-user-output` flag.
 
 **`--release-source` source**
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ pub mod id {
     pub const ARG_TOOLCHAIN_FILE: &str = "toolchain_file";
     pub const ARG_IGNORE_LOCKFILE: &str = "lockfile";
     pub const ARG_OUTPUT_FORMAT: &str = "output_format";
+    pub const ARG_NO_USER_OUTPUT: &str = "no_user_output";
     pub const ARG_VERIFY: &str = "verify_msrv";
     pub const ARG_RELEASE_SOURCE: &str = "release_source";
     pub const ARG_NO_LOG: &str = "no_log";
@@ -134,7 +135,16 @@ rustup like so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provi
             .takes_value(true)
             .possible_values(OutputFormat::custom_formats())
             .long_help("Output status messages in machine-readable format. \
-        Machine-readable status updates will be printed in the requested format to stdout.")
+            Machine-readable status updates will be printed in the requested format to stdout. \
+            Ignored when used in conjunction with the `--no-user-output` flag.")
+        )
+        .arg(Arg::new(id::ARG_NO_USER_OUTPUT)
+            .long("no-user-output")
+            .help("Disables user output")
+            .long_help("Disables user output. Useful when when `--log-target stdout` is present, \
+            so no clipping between the user output prints and log message prints will take place. \
+            When present, the `--output-format [value]` option will be ignored.")
+            .takes_value(false)
         )
         .arg(Arg::new(id::ARG_VERIFY)
             .long("verify")

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,12 +30,23 @@ impl Default for OutputFormat {
 
 impl OutputFormat {
     pub const JSON: &'static str = "json";
-    pub const NONE: &'static str = "void";
 
     /// A set of formats which may be given as a configuration option
     ///   through the CLI.
     pub fn custom_formats() -> &'static [&'static str] {
-        &[Self::JSON, Self::NONE]
+        &[Self::JSON]
+    }
+
+    /// Parse the output format from the given `&str`.
+    ///
+    /// **Panics**
+    ///
+    /// Panics if the format is not known, or can not be set by a user.
+    pub fn from_str(item: &str) -> Self {
+        match item {
+            Self::JSON => Self::Json,
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -427,12 +438,7 @@ impl<'config> TryFrom<&'config ArgMatches> for Config<'config> {
 
         let output_format = matches.value_of(id::ARG_OUTPUT_FORMAT);
         if let Some(output_format) = output_format {
-            let output_format = match output_format {
-                OutputFormat::JSON => OutputFormat::Json,
-                OutputFormat::NONE => OutputFormat::None,
-                _ => unreachable!(),
-            };
-
+            let output_format = OutputFormat::from_str(output_format);
             builder = builder.output_format(output_format);
         }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -436,10 +436,14 @@ impl<'config> TryFrom<&'config ArgMatches> for Config<'config> {
 
         builder = builder.ignore_lockfile(matches.is_present(id::ARG_IGNORE_LOCKFILE));
 
-        let output_format = matches.value_of(id::ARG_OUTPUT_FORMAT);
-        if let Some(output_format) = output_format {
-            let output_format = OutputFormat::from_str(output_format);
-            builder = builder.output_format(output_format);
+        if matches.is_present(id::ARG_NO_USER_OUTPUT) {
+            builder = builder.output_format(OutputFormat::None);
+        } else {
+            if let Some(output_format) = matches.value_of(id::ARG_OUTPUT_FORMAT) {
+                let output_format = OutputFormat::from_str(output_format);
+                builder = builder.output_format(output_format);
+            }
+            // else: use default
         }
 
         let release_source = matches.value_of(id::ARG_RELEASE_SOURCE);

--- a/tests/user_output.rs
+++ b/tests/user_output.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use crate::common::fixtures_path;
+
+mod common;
+
+#[test]
+fn expect_no_user_output() {
+    let cargo_msrv_manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let test_subject = fixtures_path().join("unbuildable-with-msrv");
+
+    let process = Command::new("cargo")
+        .args(&[
+            "run",
+            "--quiet",
+            "--manifest-path",
+            &cargo_msrv_manifest.to_str().unwrap(),
+            "--",
+            "--path",
+            test_subject.to_str().unwrap(),
+            "--no-user-output", // this is the command we're testing
+            "verify",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Unable to spawn cargo-msrv via cargo in test");
+
+    let output = process
+        .wait_with_output()
+        .expect("Waiting for process failed during test");
+
+    let _stdout = String::from_utf8_lossy(&output.stdout);
+    let _stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Unable to test for this because of: https://github.com/foresterre/cargo-msrv/issues/263
+    // assert!(stdout.is_empty()); // FIXME(foresterre): #263
+    // assert!(stderr.is_empty()); // FIXME(foresterre): #263
+}

--- a/tests/user_output.rs
+++ b/tests/user_output.rs
@@ -8,7 +8,7 @@ mod common;
 #[test]
 fn expect_no_user_output() {
     let cargo_msrv_manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
-    let test_subject = fixtures_path().join("unbuildable-with-msrv");
+    let test_subject = fixtures_path().join("1.36.0");
 
     let process = Command::new("cargo")
         .args(&[
@@ -31,10 +31,9 @@ fn expect_no_user_output() {
         .wait_with_output()
         .expect("Waiting for process failed during test");
 
-    let _stdout = String::from_utf8_lossy(&output.stdout);
-    let _stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // Unable to test for this because of: https://github.com/foresterre/cargo-msrv/issues/263
-    // assert!(stdout.is_empty()); // FIXME(foresterre): #263
-    // assert!(stderr.is_empty()); // FIXME(foresterre): #263
+    assert!(stdout.is_empty());
+    assert!(stderr.is_empty());
 }


### PR DESCRIPTION
closes  #279