### PR TITLE
Fix cargo about generation

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -1,10 +1,19 @@
 accepted = [
     "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
     "MIT",
     "MPL-2.0",
+    "OpenSSL",
     "Zlib",
-    "BSD-3-Clause"
 ]
+workarounds = ["ring"]
 
 ignore-build-dependencies = true
 ignore-dev-dependencies = true
+
+[ring]
+accepted = ["ISC", "OpenSSL"]
+
+[webpki]
+accepted = ["ISC"]


### PR DESCRIPTION
* rust-releases now depends on aws-sdk instead of rusoto
  * as a result it required some licenses which are difficult to detect by cargo-about and cargo-deny (e.g. ring and webpki)
  * cargo deny was updated (because it's part of the CI pipeline)
  * cargo about was not updated yet (it's only part of the binary release building pipeline)

This PR updates cargo-about so third party license attributions can be generated.