### PR TITLE
add feature toggle for 'rust-release-dist-source', default on

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "aws-config"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b964849038df43a2b4e0c20e29b67451af5a93108d757dd58b9e82f41a0ee8"
+checksum = "9171a6de9a57d972d40a4222a002118c3c73e5cccc7cfba803489a9c97946114"
 dependencies = [
  "aws-http",
  "aws-sdk-sso",
@@ -87,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "aws-endpoint"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d059b181b25940b751e8efecc173ceb4fe65f45d8975f56b02e98db5c42fd6"
+checksum = "134821b378ab7a752d9e99cc67a4abdd57ebbb8abc98ede4259303c011c196bb"
 dependencies = [
  "aws-smithy-http",
  "aws-types",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "aws-http"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3049066e3282c98bbf01e90459a1772ccf6c0b96cd1483c3dd5aa34bef9b9de1"
+checksum = "a75a25c07222d06eb59fc4295a6c19e6627fe94e282f77a6df32fc64629fc2e0"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -115,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d70be50ac07c3c2b5f37056271856ac00190e80c19c76c58bcbee5be0b63ec9"
+checksum = "d1281e45ff8dbfb1198d5bac9fb225d7814ff0595d054ac6035f84c262eb906e"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fcabbf95f1f13c4e28cab95c9a4bb02606f998b1ea2800713b6866be5701d"
+checksum = "ec2f782e0f9022ce579b02b4061f15fb4744ec44f0e82fb0bf0ed152412560a8"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85b9f081af2c73ee25642de1a35fa9ba7b2432e54f6bf42242e478ae53c3beb"
+checksum = "3ea2defe7917462906db17bc82503bc53300fe0090a3fba8651e7ef66b6313d7"
 dependencies = [
  "aws-endpoint",
  "aws-http",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sig-auth"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4012b5192350b5403aba19a01a5a3b1768158dab936c4269d89760970d4812bc"
+checksum = "5c5832e1b868c23a8ff52f001593eafc52e4456463bd4a4bad4483d7cf147ae2"
 dependencies = [
  "aws-sigv4",
  "aws-smithy-eventstream",
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f4b9c0c3a34e5152a0cd5e43b8f2cfd780e3bd7a245948d8787e051095ac4c"
+checksum = "2244e05b9b96423563d4476931b93a172490d33529689395313e017c14a0e1f0"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-http",
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b69dad0aefb1b64e63e0d3a1310dc50191608d8c9e226f2f241f344a7173642e"
+checksum = "d2c8dcd8e989d6d0c9cfb952fab3e22d364e680874057e0e53eedb8c7fda8a3b"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93e47a8aca2194672518d6630936507d3b54598c482f13ffe53f9b7932724bbb"
+checksum = "82d6d6bb489d9f464ea0eea0683b551be97c77b318f7cc56521e088a3778d720"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -255,9 +255,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98bcfcb063d29c7cc7bb0a64830afe606090de75533c10a11a05460d814e8d9"
+checksum = "fec5fac07acddb24956a807b998f0e3de0191c572a815e545e5bcb7b03f8bd9e"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8bbe92ecdc4e39a612359b09994c45d000591d4951aa7343443f44b47e6696"
+checksum = "3cf5331725af34032d770a313bcc407f8b66866515157bbea598b9054a7ca4ce"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23fdf1253855af3bb4abb25e42ad3152a71241af89014eebf27c14c7a59b81d"
+checksum = "d9348b599cd1107b814f2723a98f2e816baba245412a99499a34bda8c32da5d3"
 dependencies = [
  "aws-smithy-http",
  "bytes",
@@ -302,18 +302,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cc19c372b0a561aa6bfc5dfdd917da7c7b1641d3bc9049ca4d7b197bb616a09"
+checksum = "95cca947d42c1e399b19c70e5869963581fe89d9430cddb67a9f0a3a6ebe07fa"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-query"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8254e49a237e9dc0301a4683c424a825f4220420b241ec4eb51e959a70626d8a"
+checksum = "68516fb824e7479fdbd1cc824311edebd14a6c30635c65b5c4e258f3408ebb9e"
 dependencies = [
  "aws-smithy-types",
  "urlencoding",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde96306a54777ec8781aa510830e242de614aa5746274713f5ecac0779f644f"
+checksum = "78f74fe1257d0f1d3bf2ebf4ddcad2da2679c1c05ddccd0bc79436868b96ab1c"
 dependencies = [
  "itoa",
  "num-integer",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b0466594a86074a6e96b11284f9a9ddc90c5c5b7d6144ab357a90be49d28c4"
+checksum = "d64610202b08bc7ef25d8df7b34de7513a801b0edb5b941a209fff244551c11b"
 dependencies = [
  "thiserror",
  "xmlparser",
@@ -343,11 +343,12 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433fd128ea727e9b83b34c72c6d4db1b900f067760fa27b387694fe896633142"
+checksum = "5af23ce8f235a6378e1837a30abc3d02f8d2b04dc526b4a28724f7ad2b85af5d"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-client",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -567,8 +568,8 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "libc",
- "mio",
- "parking_lot",
+ "mio 0.7.14",
+ "parking_lot 0.11.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -1049,6 +1050,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
 name = "miow"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,7 +1219,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.1",
 ]
 
 [[package]]
@@ -1220,6 +1244,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1400,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "rust-releases-rust-dist"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbac750f06fb549f0c59df609f3b4bc964f7c6a7355c2a8c1c6a223ef22c640"
+checksum = "9cd1d9bd3bc8ada9d800f79320b87ef5098ea4aefe6c7579626fa698038af2f9"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -1572,7 +1609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fd5867f1c4f2c5be079aee7a2adf1152ebb04a4bc4d341f504b7dece607ed4"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.7.14",
  "signal-hook",
 ]
 
@@ -1751,19 +1788,20 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio",
+ "mio 0.8.0",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
@@ -1829,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
+checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2139,6 +2177,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/foresterre/cargo-msrv"
 keywords = ["msrv", "rust-version", "toolchain", "find", "minimum"]
 categories = ["development-tools", "development-tools::cargo-plugins", "command-line-utilities"]
 
+[features]
+default = ["rust-releases-dist-source"]
+rust-releases-dist-source = ["rust-releases/rust-releases-rust-dist"]
+
 [package.metadata]
 msrv = "1.54.0"
 
@@ -52,7 +56,7 @@ features = ["json"]
 [dependencies.rust-releases]
 version = "0.22.0"
 default-features = false
-features = ["rust-releases-rust-changelog", "rust-releases-rust-dist"]
+features = ["rust-releases-rust-changelog"]
 
 [dev-dependencies]
 parameterized = "0.3.1"

--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -12,6 +12,15 @@ You can install cargo-msrv from source by using Cargo, the Rust package manager 
 cargo install cargo-msrv
 ```
 
+**How to install the latest stable release more quickly?**
+
+Similar to the above, but allows for only the default channel to obtain a list of rustc releases.
+This compiles about 40% faster and produces binaries about half the size in the range of 4.5MB.
+
+```shell
+cargo install cargo-msrv --no-default-features
+```
+
 **How to install the latest development release?**
 
 You may install _cargo-msrv_ from GitHub:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -162,12 +162,17 @@ rustup like so: `rustup run <toolchain> <COMMAND...>`. You'll only need to provi
             DEPRECATED: use the `cargo msrv verify` subcommand instead.")
             .takes_value(false)
         )
-        .arg(Arg::new(id::ARG_RELEASE_SOURCE)
+        .arg({
+            #[cfg(feature = "rust-releases-dist-source")]
+            let possible_values = &["rust-changelog", "rust-dist"];
+            #[cfg(not(feature = "rust-releases-dist-source"))]
+            let possible_values = &["rust-changelog"];
+            Arg::new(id::ARG_RELEASE_SOURCE)
             .long("release-source")
             .help("Select the rust-releases source to use as the release index")
             .takes_value(true)
-            .possible_values(&["rust-changelog", "rust-dist"])
-            .default_value("rust-changelog")
+            .possible_values(possible_values)
+            .default_value("rust-changelog")}
         )
         .arg(Arg::new(id::ARG_NO_LOG)
             .long("no-log")

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -90,6 +90,7 @@ impl From<ModeIntent> for &'static str {
 #[derive(Debug, Clone, Copy)]
 pub enum ReleaseSource {
     RustChangelog,
+    #[cfg(feature = "rust-releases-dist-source")]
     RustDist,
 }
 
@@ -97,6 +98,7 @@ impl From<ReleaseSource> for &'static str {
     fn from(value: ReleaseSource) -> Self {
         match value {
             ReleaseSource::RustChangelog => "rust-changelog",
+            #[cfg(feature = "rust-releases-dist-source")]
             ReleaseSource::RustDist => "rust-dist",
         }
     }
@@ -108,6 +110,7 @@ impl TryFrom<&str> for ReleaseSource {
     fn try_from(source: &str) -> Result<Self, Self::Error> {
         match source {
             "rust-changelog" => Ok(Self::RustChangelog),
+            #[cfg(feature = "rust-releases-dist-source")]
             "rust-dist" => Ok(Self::RustDist),
             s => Err(CargoMSRVError::RustReleasesSourceParseError(s.to_string())),
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -58,6 +58,7 @@ pub enum CargoMSRVError {
     RustReleasesSource(#[from] rust_releases::RustChangelogError),
 
     #[error(transparent)]
+    #[cfg(feature = "rust-releases-dist-source")]
     RustReleasesRustDistSource(#[from] rust_releases::RustDistError),
 
     #[error("Unable to parse rust-releases source from '{0}'")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,9 @@
 #[macro_use]
 extern crate tracing;
 
-use rust_releases::{
-    semver, Channel, FetchResources, ReleaseIndex, RustChangelog, RustDist, Source,
-};
+#[cfg(feature = "rust-releases-dist-source")]
+use rust_releases::RustDist;
+use rust_releases::{semver, Channel, FetchResources, ReleaseIndex, RustChangelog, Source};
 
 use crate::config::{Config, ModeIntent, ReleaseSource};
 use crate::errors::{CargoMSRVError, TResult};
@@ -61,6 +61,7 @@ fn fetch_index(config: &Config) -> TResult<ReleaseIndex> {
         ReleaseSource::RustChangelog => {
             RustChangelog::fetch_channel(Channel::Stable)?.build_index()?
         }
+        #[cfg(feature = "rust-releases-dist-source")]
         ReleaseSource::RustDist => RustDist::fetch_channel(Channel::Stable)?.build_index()?,
     };
 


### PR DESCRIPTION
I did the change for myself initially but thought it might be useful for others as well, hence the PR.

I'd be glad to receive feedback to make it palatable :).

----

This is a non-breaking change which allows users to install with

```
cargo install --no-default-features cargo-msrv
```

and more quickly with less dependencies. For me it took 1m02s for the full build and 41s with `--no-default-features`.

Since the 'changelog' release channel is the default, there is no differnece in typical usage.

The binary size shrinks from 9.5MB to 4.4MB as well.
