### PR TITLE
Experiment with a new reporter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub(crate) mod outcome;
 pub(crate) mod paths;
 pub(crate) mod releases;
 pub mod reporter;
+pub(crate) mod reporter_new;
 pub(crate) mod result;
 pub(crate) mod search_methods;
 pub(crate) mod subcommands;

--- a/src/reporter_new.rs
+++ b/src/reporter_new.rs
@@ -1,0 +1,96 @@
+use crate::manifest::bare_version::BareVersion;
+
+#[derive(Debug)]
+pub struct Reporter<T: OutputType, W> {
+    output_type: T,
+    writer: W,
+}
+
+impl<W: std::io::Write> Report<HumanOutput> for Reporter<HumanOutput, W> {
+    fn report_event<E>(&mut self, event: E)
+    where
+        E: Event<HumanOutput>,
+    {
+        let writer = &mut self.writer;
+        event.write_formatted_event(writer);
+    }
+}
+
+impl<W: std::io::Write> Report<JsonOutput> for Reporter<JsonOutput, W> {
+    fn report_event<E>(&mut self, event: E)
+    where
+        E: Event<JsonOutput>,
+    {
+        let writer = &mut self.writer;
+        event.write_formatted_event(writer);
+    }
+}
+
+// -- Traits which handle reporting an event, to be implemented by a specific reporter
+
+pub trait Report<T> {
+    fn report_event<E>(&mut self, event: E)
+    where
+        T: OutputType,
+        E: Event<T>;
+}
+
+pub trait OutputType {}
+
+pub struct HumanOutput;
+pub struct JsonOutput;
+
+impl OutputType for HumanOutput {}
+impl OutputType for JsonOutput {}
+
+pub trait Event<T> {
+    fn write_formatted_event<W>(&self, writer: &mut W)
+    where
+        W: std::io::Write;
+}
+
+// -- Example event, which implements an Event
+
+struct MsrvFoundEvent {
+    msrv: BareVersion,
+}
+
+impl MsrvFoundEvent {}
+
+impl Event<HumanOutput> for MsrvFoundEvent {
+    fn write_formatted_event<W>(&self, writer: &mut W)
+    where
+        W: std::io::Write,
+    {
+        let _ = writer.write_fmt(format_args!("Message: {}", "Hello Human!"));
+    }
+}
+
+impl Event<JsonOutput> for MsrvFoundEvent {
+    fn write_formatted_event<W>(&self, writer: &mut W)
+    where
+        W: std::io::Write,
+    {
+        let _ = writer.write_fmt(format_args!("{{ \"message\": \"{}\" }}", "Hello Json!"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::manifest::bare_version::BareVersion;
+    use crate::reporter_new::{JsonOutput, MsrvFoundEvent, Report, Reporter};
+
+    #[test]
+    fn test_case() {
+        let mut reporter = Reporter {
+            output_type: JsonOutput,
+            writer: std::io::stdout(),
+        };
+
+        let event = MsrvFoundEvent {
+            msrv: BareVersion::TwoComponents(1, 2),
+        };
+
+        reporter.report_event(event);
+    }
+}


### PR DESCRIPTION
The currently used reporter is a struct implementing a trait named Output.
The Output struct has several methods which represent certain events.
For each type of output, say human-readable or json, a struct is created for which Output is implemented.

One problem with the current implementation is that it doesn't scale neatly. When functionality is added which reports its progress in a slightly different way, there is a choice to be made:
 * Add a new event on the Output trait, or,
 * Re-use an existing method

 In the first case, the Output traits becomes messy.
 In the second case, the implementation becomes messy, as it either becomes very generic and takes a simple message (e.g. string), which needs to be pre-formatted by the caller [this is actually a fairly reasonable and  practical alternative solution to the experimental implementation], or it becomes a conditional mess.

The experimental solution takes a different approach: when we want to output something, we take a generic writer, and write Events to it. An Event is bound by the type of output. For every event implementation, we thus must separately implement output per output type. For example: if we define a certain event to be `SampleEvent`, then for the Json output type, we would implement `Event<Json> for SampleEvent`, and for the Human (readable) output type, we would respectively implement `Event<Human> for SampleEvent`.

Events take a writer (W: Write), because returning a formatted value instead would require ownership over the return value, which usually allocates unnecessarily.

While these types seem to work really well for stateless printing, it needs a bit more work to determine how well it works for stateful printing. Our MSRV find action currently reports the amount of toolchains checked, and how many steps at most would still need to be taken (i.e. it reports the progression in a progressbar style). Probably we don't need to store the state in the events however, since the loop also already tracks the state, and we can simply supply the current state to a (name TBD) ProgressEvent.

Additionally, we need to experiment a bit with verbosity on the caller. If every print requires a builder or new with many parameters, calling report_event(..) prints becomes really verbose, and may distract from the business logic. There are several ways to solve this, for example by using functions or macro's to hide the boilerplate.'

Related issues: #182 