### PR TITLE
Expand accepted version spec for --min and --max

### DIFF
--- a/src/cli_new/configurators/max_version.rs
+++ b/src/cli_new/configurators/max_version.rs
@@ -11,7 +11,7 @@ impl Configure for MaxVersion {
         opts: &'c CargoMsrvOpts,
     ) -> TResult<ConfigBuilder<'c>> {
         if let Some(max) = &opts.find_opts.rust_releases_opts.max {
-            Ok(builder.maximum_version(max.to_semver_version()))
+            Ok(builder.maximum_version(max.clone()))
         } else {
             Ok(builder)
         }

--- a/src/cli_new/configurators/max_version.rs
+++ b/src/cli_new/configurators/max_version.rs
@@ -11,7 +11,7 @@ impl Configure for MaxVersion {
         opts: &'c CargoMsrvOpts,
     ) -> TResult<ConfigBuilder<'c>> {
         if let Some(max) = &opts.find_opts.rust_releases_opts.max {
-            Ok(builder.maximum_version(max.clone()))
+            Ok(builder.maximum_version(max.to_semver_version()))
         } else {
             Ok(builder)
         }

--- a/src/cli_new/configurators/min_version.rs
+++ b/src/cli_new/configurators/min_version.rs
@@ -15,7 +15,7 @@ impl Configure for MinVersion {
         opts: &'c CargoMsrvOpts,
     ) -> TResult<ConfigBuilder<'c>> {
         if let Some(v) = &opts.find_opts.rust_releases_opts.min {
-            let version = v.as_version();
+            let version = v.as_bare_version();
             Ok(builder.minimum_version(version))
         } else {
             configure_min_version_not_as_opt(builder, opts)
@@ -78,7 +78,7 @@ fn set_min_version_from_manifest<'c>(
         .and_then(Item::as_str)
     {
         let edition = edition.parse::<Edition>()?;
-        Ok(builder.minimum_version(edition.as_version()))
+        Ok(builder.minimum_version(edition.as_bare_version()))
     } else {
         Ok(builder)
     }

--- a/src/cli_new/rust_releases_opts.rs
+++ b/src/cli_new/rust_releases_opts.rs
@@ -1,6 +1,6 @@
 use crate::manifest::bare_version;
 use crate::manifest::bare_version::BareVersion;
-use crate::{semver, ReleaseSource};
+use crate::ReleaseSource;
 use clap::AppSettings;
 use clap::Args;
 use std::str::FromStr;
@@ -20,7 +20,8 @@ pub struct RustReleasesOpts {
 
     /// Most recent version to take into account
     ///
-    /// Given version must match a valid Rust toolchain, and be semver compatible.
+    /// Given version must match a valid Rust toolchain, and be semver compatible, or
+    /// be a two component `major.minor` version.
     #[clap(long, value_name = "VERSION_SPEC", alias = "maximum")]
     pub max: Option<BareVersion>,
 
@@ -39,10 +40,10 @@ pub enum EditionOrVersion {
 }
 
 impl EditionOrVersion {
-    pub fn as_version(&self) -> semver::Version {
+    pub fn as_bare_version(&self) -> bare_version::BareVersion {
         match self {
-            Self::Edition(edition) => edition.as_version(),
-            Self::Version(version) => version.to_semver_version(),
+            Self::Edition(edition) => edition.as_bare_version(),
+            Self::Version(version) => version.clone(),
         }
     }
 }
@@ -68,11 +69,11 @@ impl FromStr for Edition {
 }
 
 impl Edition {
-    pub fn as_version(&self) -> semver::Version {
+    pub fn as_bare_version(&self) -> bare_version::BareVersion {
         match self {
-            Self::Edition2015 => semver::Version::new(1, 0, 0),
-            Self::Edition2018 => semver::Version::new(1, 31, 0),
-            Self::Edition2021 => semver::Version::new(1, 56, 0),
+            Self::Edition2015 => BareVersion::ThreeComponents(1, 0, 0),
+            Self::Edition2018 => BareVersion::ThreeComponents(1, 31, 0),
+            Self::Edition2021 => BareVersion::ThreeComponents(1, 56, 0),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use rust_releases::semver;
 
 use crate::errors::{CargoMSRVError, TResult};
 use crate::log_level::LogLevel;
+use crate::manifest::bare_version;
 
 pub(crate) mod list;
 pub(crate) mod set;
@@ -213,8 +214,8 @@ pub struct Config<'a> {
     check_command: Vec<&'a str>,
     crate_path: Option<PathBuf>,
     include_all_patch_releases: bool,
-    minimum_version: Option<semver::Version>,
-    maximum_version: Option<semver::Version>,
+    minimum_version: Option<bare_version::BareVersion>,
+    maximum_version: Option<bare_version::BareVersion>,
     search_method: SearchMethod,
     output_toolchain_file: bool,
     ignore_lockfile: bool,
@@ -273,11 +274,11 @@ impl<'a> Config<'a> {
         self.include_all_patch_releases
     }
 
-    pub fn minimum_version(&self) -> Option<&semver::Version> {
+    pub fn minimum_version(&self) -> Option<&bare_version::BareVersion> {
         self.minimum_version.as_ref()
     }
 
-    pub fn maximum_version(&self) -> Option<&semver::Version> {
+    pub fn maximum_version(&self) -> Option<&bare_version::BareVersion> {
         self.maximum_version.as_ref()
     }
 
@@ -361,12 +362,12 @@ impl<'a> ConfigBuilder<'a> {
         self
     }
 
-    pub fn minimum_version(mut self, version: semver::Version) -> Self {
+    pub fn minimum_version(mut self, version: bare_version::BareVersion) -> Self {
         self.inner.minimum_version = Some(version);
         self
     }
 
-    pub fn maximum_version(mut self, version: semver::Version) -> Self {
+    pub fn maximum_version(mut self, version: bare_version::BareVersion) -> Self {
         self.inner.maximum_version = Some(version);
         self
     }


### PR DESCRIPTION
Expand accepted version spec for --min and --max

Previously, --min and --max would strictly take semver versions. With this commit, we are more liberal, and also allow two component semver versions.

Notably, the max version may be too liberal, as given version 1.56.1 will now be accepted if the max version is 1.56.0. This is accepted as a 'workaround', which allows the version 1.56.1 to match when a given version spec is `1.56`.

--

Be more precise in version ranges accepted by --min and --max

In the previous commit, the version taken by --min and --max would already be a bare version, but the config still used a strict semver version. As a result, a workaround had to be applied to accept two component bare versions where the version compared to, had a patch version > 0. As an example, this allowed the version 1.56.1 to match when a given version spec is `1.56`.
However, this also resulted in a (known) regression, where a full semver version 1.56.0 still matched a given version spec 1.56.1 (patch version 1 > patch version 0, which was an unintended, but known side effect of the previous version of the implementation).

Now we replaced the min and max versions in the config to be bare versions, and implemented two comparators (as regular methods, as the Eq, Ord and PartialOrd contract would not be upheld) accordingly: BareVersion::is_at_least and BareVersion::is_at_most.

--

closes #278

