### PR TITLE
simplify output format trait

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -1,7 +1,7 @@
-pub trait FormatUserOutput<T> {
-    /// Format user output as output type `T`.
-    fn format_line(&self) -> String;
-}
+pub trait FormatUserOutput {
+    /// Format user output as human-readable string
+    fn format_human(&self) -> String;
 
-pub struct Json;
-pub struct Human;
+    /// Format user output as json string
+    fn format_json(&self) -> String;
+}

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -1,4 +1,4 @@
-use crate::formatter::{FormatUserOutput, Human, Json};
+use crate::formatter::FormatUserOutput;
 use crate::toolchain::OwnedToolchainSpec;
 use comfy_table::presets::UTF8_FULL;
 use comfy_table::{ContentArrangement, Table};
@@ -23,17 +23,11 @@ impl Outcome {
     }
 
     pub fn is_success(&self) -> bool {
-        match self {
-            Self::Success { .. } => true,
-            Self::Failure { .. } => false,
-        }
+        matches!(self, Self::Success(_))
     }
 
     pub fn version(&self) -> &semver::Version {
-        match self {
-            Self::Success(outcome) => outcome.toolchain_spec.version(),
-            Self::Failure(outcome) => outcome.toolchain_spec.version(),
-        }
+        self.toolchain_spec().version()
     }
 
     pub fn toolchain_spec(&self) -> &OwnedToolchainSpec {
@@ -49,17 +43,15 @@ pub struct SuccessOutcome {
     pub(crate) toolchain_spec: OwnedToolchainSpec,
 }
 
-impl FormatUserOutput<Human> for SuccessOutcome {
-    fn format_line(&self) -> String {
+impl FormatUserOutput for SuccessOutcome {
+    fn format_human(&self) -> String {
         format!(
             "Check for toolchain '{}' succeeded",
             self.toolchain_spec.spec(),
         )
     }
-}
 
-impl FormatUserOutput<Json> for SuccessOutcome {
-    fn format_line(&self) -> String {
+    fn format_json(&self) -> String {
         let version = self.toolchain_spec.version();
         let toolchain = self.toolchain_spec.spec();
 
@@ -81,8 +73,8 @@ pub struct FailureOutcome {
     pub(crate) error_message: String,
 }
 
-impl FormatUserOutput<Human> for FailureOutcome {
-    fn format_line(&self) -> String {
+impl FormatUserOutput for FailureOutcome {
+    fn format_human(&self) -> String {
         let mut table = Table::new();
         table
             .load_preset(UTF8_FULL)
@@ -95,10 +87,8 @@ impl FormatUserOutput<Human> for FailureOutcome {
             table
         )
     }
-}
 
-impl FormatUserOutput<Json> for FailureOutcome {
-    fn format_line(&self) -> String {
+    fn format_json(&self) -> String {
         let version = self.toolchain_spec.version();
         let toolchain = self.toolchain_spec.spec();
         let error_message = self.error_message.as_str();

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -4,7 +4,7 @@ use crate::Config;
 use rust_releases::semver;
 
 use crate::config::{ModeIntent, OutputFormat};
-use crate::formatter::{FormatUserOutput, Human, Json};
+use crate::formatter::FormatUserOutput;
 use crate::outcome::{FailureOutcome, SuccessOutcome};
 
 pub mod json;
@@ -39,33 +39,25 @@ pub fn write_succeeded_check(
     config: &Config,
     output: &impl Output,
 ) {
-    if config.no_check_feedback() {
-        return;
-    }
-
-    match config.output_format() {
-        OutputFormat::Human => {
-            output.write_line(&FormatUserOutput::<Human>::format_line(success_outcome));
-        }
-        OutputFormat::Json => {
-            output.write_line(&FormatUserOutput::<Json>::format_line(success_outcome));
-        }
-        _ => {}
-    };
+    write(success_outcome, config, output);
 }
 
 pub fn write_failed_check(failure_outcome: &FailureOutcome, config: &Config, output: &impl Output) {
+    write(failure_outcome, config, output);
+}
+
+fn write(outcome: &impl FormatUserOutput, config: &Config, output: &impl Output) {
     if config.no_check_feedback() {
         return;
     }
 
     match config.output_format() {
         OutputFormat::Human => {
-            output.write_line(&FormatUserOutput::<Human>::format_line(failure_outcome));
+            output.write_line(&outcome.format_human());
         }
         OutputFormat::Json => {
-            output.write_line(&FormatUserOutput::<Json>::format_line(failure_outcome));
+            output.write_line(&outcome.format_json());
         }
-        _ => {}
+        OutputFormat::None => {}
     };
 }


### PR DESCRIPTION
simplify the output formatting trait.

the old implementation using a generic trait with 'marker' structs has an unfortunate side effect- adding a new output format type will fail *silently* if you forget to implement the new output type for a given struct. By moving the output formats into the trait itself, you can't forget to implement a new output type anywhere (since it will be a compilation error)