### PR TITLE
Use clap's ArgEnum instead of manually implementing it for the 'list' command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,7 +121,7 @@ pub(in crate::cli) enum SubCommand {
 #[clap(next_help_heading = "LIST OPTIONS", setting = AppSettings::DeriveDisplayOrder)]
 pub(in crate::cli) struct ListOpts {
     /// Display the MSRV's of crates that your crate depends on
-    #[clap(long, possible_values = ListMsrvVariant::variants(), default_value_t)]
+    #[clap(long, arg_enum, default_value_t)]
     variant: ListMsrvVariant,
 }
 

--- a/src/config/list.rs
+++ b/src/config/list.rs
@@ -1,54 +1,18 @@
-use std::fmt::Formatter;
-use std::{fmt, str::FromStr};
+use clap::ArgEnum;
 
 #[derive(Clone, Debug)]
 pub struct ListCmdConfig {
     pub variant: ListMsrvVariant,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, ArgEnum)]
 pub enum ListMsrvVariant {
     DirectDeps,
-    OrderedByMSRV,
-}
-
-pub(crate) const DIRECT_DEPS: &str = "direct-deps";
-pub(crate) const ORDERED_BY_MSRV: &str = "ordered-by-msrv";
-
-impl FromStr for ListMsrvVariant {
-    type Err = crate::CargoMSRVError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            DIRECT_DEPS => Self::DirectDeps,
-            ORDERED_BY_MSRV => Self::OrderedByMSRV,
-            elsy => {
-                return Err(crate::CargoMSRVError::InvalidConfig(format!(
-                    "No such list variant '{}'",
-                    elsy
-                )))
-            }
-        })
-    }
-}
-
-impl fmt::Display for ListMsrvVariant {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::DirectDeps => write!(f, "{}", DIRECT_DEPS),
-            Self::OrderedByMSRV => write!(f, "{}", ORDERED_BY_MSRV),
-        }
-    }
-}
-
-impl ListMsrvVariant {
-    pub(crate) const fn variants() -> &'static [&'static str] {
-        &[DIRECT_DEPS, ORDERED_BY_MSRV]
-    }
+    OrderedByMsrv,
 }
 
 impl Default for ListMsrvVariant {
     fn default() -> Self {
-        Self::OrderedByMSRV
+        Self::OrderedByMsrv
     }
 }

--- a/src/dependencies/formatter.rs
+++ b/src/dependencies/formatter.rs
@@ -19,7 +19,7 @@ pub(crate) fn format(
 ) -> Option<String> {
     match variant {
         ListMsrvVariant::DirectDeps => direct_deps::format(graph, format),
-        ListMsrvVariant::OrderedByMSRV => ordered_by_msrv::format(graph, format),
+        ListMsrvVariant::OrderedByMsrv => ordered_by_msrv::format(graph, format),
     }
 }
 

--- a/src/dependencies/formatter/direct_deps.rs
+++ b/src/dependencies/formatter/direct_deps.rs
@@ -84,7 +84,7 @@ fn format_json<'a>(values: impl Iterator<Item = Values<'a>>) -> String {
 
     let json = json::object! {
         reason: "list",
-        variant: crate::config::list::DIRECT_DEPS,
+        variant: "direct-deps",
         success: true,
         list: objects,
     };

--- a/src/dependencies/formatter/ordered_by_msrv.rs
+++ b/src/dependencies/formatter/ordered_by_msrv.rs
@@ -78,7 +78,7 @@ fn format_json(values: impl Iterator<Item = Values>) -> String {
 
     let json = json::object! {
         reason: "list",
-        variant: crate::config::list::ORDERED_BY_MSRV,
+        variant: "ordered-by-msrv",
         success: true,
         list: objects,
     };


### PR DESCRIPTION
use `Clap`'s built-in `ArgEnum` trait, rather than implementing this manually