### PR TITLE
Add option which allows users to specify the rust-version to be verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 
 ## [Unreleased]
 
+### Added
+
+* Subcommand `cargo msrv verify` now supports setting a custom Rust version via the `--rust-version <VERSION>` argument, 
+  which can be used to check for a crate's compatibility against a specific Rust version. 
+
 ### Changed
 
 * CLI options are now grouped by option types
@@ -19,6 +24,7 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 ### Fixed
 
 * Subcommand `cargo msrv set` will now return an error when the Cargo manifest contains a virtual workspace.
+* The program will no longer return an unformatted message when a command failed and the output format was set to json. 
 
 [Unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.15.1...HEAD
 

--- a/book/src/commands/verify.md
+++ b/book/src/commands/verify.md
@@ -16,6 +16,12 @@ If the check fails, the program returns with a non-zero exit code.
 
 <!-- # OPTIONS -->
 
+## OPTIONS
+
+**`--rust-version` version**
+
+Specify the Rust version of a Rust toolchain, against which the crate will be checked for compatibility. 
+
 # EXAMPLES
 
 1. Verify whether the MSRV specified in the Cargo manifest is satisfiable (Good case).
@@ -85,3 +91,10 @@ cargo msrv --path path/to/my/crate verify
 
 This example shows how to use arguments (in this case `--path`) shared between the default cargo-msrv command and verify.
 Note that shared arguments must be specified before the subcommand (here `verify`).
+
+4. Run the 'verify' subcommand using a self-determined Rust version.
+
+```shell
+cargo msrv verify --rust-version 1.56
+```
+

--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -16,7 +16,7 @@ fn main() {
         match _main(std::env::args_os) {
             Ok(_guard) => ExitCode::Success,
             Err(err) => {
-                eprintln!("{}", err);
+                tracing::error!("{}", err);
                 ExitCode::Failure
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -152,6 +152,12 @@ pub(in crate::cli) struct VerifyOpts {
 
     #[clap(flatten)]
     pub(in crate::cli) custom_check: CustomCheckOpts,
+
+    /// The Rust version, to check against for toolchain compatibility
+    ///
+    /// If not set, the MSRV will be parsed from the Cargo manifest instead.
+    #[clap(long, value_name = "rust-version")]
+    rust_version: Option<BareVersion>,
 }
 
 // Interpret the CLI config frontend as general Config

--- a/src/cli/configurators/sub_command_configurator.rs
+++ b/src/cli/configurators/sub_command_configurator.rs
@@ -1,7 +1,8 @@
 use crate::cli::configurators::Configure;
-use crate::cli::{CargoMsrvOpts, ListOpts, SetOpts, SubCommand};
+use crate::cli::{CargoMsrvOpts, ListOpts, SetOpts, SubCommand, VerifyOpts};
 use crate::config::list::ListCmdConfig;
 use crate::config::set::SetCmdConfig;
+use crate::config::verify::VerifyCmdConfig;
 use crate::config::{ConfigBuilder, SubCommandConfig};
 use crate::TResult;
 
@@ -20,8 +21,15 @@ impl Configure for SubCommandConfigurator {
                 SubCommand::Set(opts) => {
                     return configure_set(builder, opts);
                 }
+                SubCommand::Verify(opts) => {
+                    return configure_verify(builder, opts);
+                }
                 _ => {}
             }
+        }
+
+        if opts.verify {
+            return configure_deprecated_verify_flag(builder);
         }
 
         Ok(builder)
@@ -46,5 +54,24 @@ fn configure_set<'c>(builder: ConfigBuilder<'c>, opts: &'c SetOpts) -> TResult<C
     };
 
     let config = SubCommandConfig::SetConfig(config);
+    Ok(builder.sub_command_config(config))
+}
+
+fn configure_verify<'c>(
+    builder: ConfigBuilder<'c>,
+    opts: &'c VerifyOpts,
+) -> TResult<ConfigBuilder<'c>> {
+    let config = VerifyCmdConfig {
+        rust_version: opts.rust_version.clone(),
+    };
+
+    let config = SubCommandConfig::VerifyConfig(config);
+    Ok(builder.sub_command_config(config))
+}
+
+fn configure_deprecated_verify_flag(builder: ConfigBuilder) -> TResult<ConfigBuilder> {
+    let config = VerifyCmdConfig { rust_version: None };
+
+    let config = SubCommandConfig::VerifyConfig(config);
     Ok(builder.sub_command_config(config))
 }

--- a/src/config/verify.rs
+++ b/src/config/verify.rs
@@ -1,0 +1,6 @@
+use crate::manifest::bare_version::BareVersion;
+
+#[derive(Clone, Debug)]
+pub struct VerifyCmdConfig {
+    pub rust_version: Option<BareVersion>,
+}

--- a/src/ctx.rs
+++ b/src/ctx.rs
@@ -1,0 +1,22 @@
+use crate::paths::crate_root_folder;
+use crate::{Config, TResult};
+use once_cell::unsync::OnceCell;
+use std::path::{Path, PathBuf};
+
+/// Context which provides a way to lazily initialize values.
+/// Once initialized, the initialized properties can be re-used.
+#[derive(Debug, Default, Clone)]
+pub struct ComputedCtx {
+    manifest_path: OnceCell<PathBuf>,
+}
+
+impl ComputedCtx {
+    /// Get the manifest path from the crate root folder.
+    pub fn manifest_path(&self, config: &Config) -> TResult<&Path> {
+        let path = self
+            .manifest_path
+            .get_or_try_init(|| crate_root_folder(config).map(|p| p.join("Cargo.toml")))?;
+
+        Ok(path)
+    }
+}

--- a/src/subcommands/verify.rs
+++ b/src/subcommands/verify.rs
@@ -1,5 +1,5 @@
 use std::convert::TryFrom;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use rust_releases::{semver, Release, ReleaseIndex};
 use toml_edit::Document;
@@ -7,19 +7,23 @@ use toml_edit::Document;
 use crate::check::Check;
 use crate::config::{Config, ModeIntent};
 use crate::errors::{CargoMSRVError, IoErrorSource, TResult};
+use crate::manifest::bare_version::BareVersion;
 use crate::manifest::{CargoManifest, CargoManifestParser, TomlParser};
 use crate::outcome::Outcome;
-use crate::paths::crate_root_folder;
 use crate::reporter::Output;
 use crate::subcommands::SubCommand;
 use crate::toolchain::ToolchainSpec;
 
+/// Verifier which determines whether a given Rust version is deemed compatible or not.
 pub struct Verify<'index, C: Check> {
     release_index: &'index ReleaseIndex,
     runner: C,
 }
 
 impl<'index, C: Check> Verify<'index, C> {
+    /// Instantiate the verifier using a release index and a runner.
+    ///
+    /// The runner is used to determine whether a given Rust version will be deemed compatible or not.
     pub fn new(release_index: &'index ReleaseIndex, runner: C) -> Self {
         Self {
             release_index,
@@ -29,66 +33,151 @@ impl<'index, C: Check> Verify<'index, C> {
 }
 
 impl<'index, C: Check> SubCommand for Verify<'index, C> {
+    /// Run the verifier against a Rust version which is obtained from the config.
     fn run<R: Output>(&self, config: &Config, reporter: &R) -> TResult<()> {
-        verify_msrv(config, reporter, self.release_index, &self.runner)
+        let rust_version = RustVersion::try_from_config(config)?;
+
+        let result = verify_msrv(
+            config,
+            reporter,
+            self.release_index,
+            rust_version,
+            &self.runner,
+        );
+
+        // report outcome
+        report_result(result.as_ref(), config, reporter);
+
+        result.map(|_| ())
     }
 }
 
-// NB: only public for integration testing
+/// Report the outcome to the user
+fn report_result<R: Output>(
+    result: Result<&Outcome, &CargoMSRVError>,
+    config: &Config,
+    reporter: &R,
+) {
+    match result.as_ref() {
+        Ok(outcome) => {
+            reporter.finish_success(ModeIntent::Verify, Some(outcome.version()));
+        }
+        Err(CargoMSRVError::SubCommandVerify(Error::VerifyFailed { .. })) => {
+            let cmd = config.check_command_string();
+            reporter.finish_failure(ModeIntent::Verify, Some(&cmd));
+        }
+        Err(_) => {}
+    };
+}
+
+/// Parse the cargo manifest from the given path.
+fn parse_manifest(path: &Path) -> TResult<CargoManifest> {
+    let contents = std::fs::read_to_string(path).map_err(|error| CargoMSRVError::Io {
+        error,
+        source: IoErrorSource::ReadFile(path.to_path_buf()),
+    })?;
+
+    let manifest = CargoManifestParser::default().parse::<Document>(&contents)?;
+    CargoManifest::try_from(manifest)
+}
+
+/// Verify whether a Cargo project is compatible with a `rustup run` command,
+/// for the (given or specified) `rust_version`.
 fn verify_msrv<R: Output, C: Check>(
     config: &Config,
     reporter: &R,
     release_index: &ReleaseIndex,
+    rust_version: RustVersion,
     runner: &C,
-) -> TResult<()> {
-    let crate_folder = crate_root_folder(config)?;
-    let cargo_toml = crate_folder.join("Cargo.toml");
-
-    let contents = std::fs::read_to_string(&cargo_toml).map_err(|error| CargoMSRVError::Io {
-        error,
-        source: IoErrorSource::ReadFile(cargo_toml.clone()),
-    })?;
-
-    let manifest = CargoManifestParser::default().parse::<Document>(&contents)?;
-    let manifest = CargoManifest::try_from(manifest)?;
-
-    let version = manifest
-        .minimum_rust_version()
-        .ok_or_else(|| CargoMSRVError::NoMSRVKeyInCargoToml(cargo_toml.clone()))?;
-    let version = version.try_to_semver(release_index.releases().iter().map(Release::version))?;
-
-    let cmd = config.check_command_string();
+) -> TResult<Outcome> {
     reporter.mode(ModeIntent::Verify);
 
+    let bare_version = rust_version.version();
+    let version =
+        bare_version.try_to_semver(release_index.releases().iter().map(Release::version))?;
+
     let toolchain = ToolchainSpec::new(version, config.target());
-    let status = runner.check(config, &toolchain)?;
-    report_status(reporter, &status, &cmd);
+    let outcome = runner.check(config, &toolchain)?;
 
-    if status.is_success() {
-        Ok(())
-    } else {
-        Err(CargoMSRVError::SubCommandVerify(Error::VerifyFailed {
-            expected_msrv: version.clone(),
-            manifest: cargo_toml,
-        }))
-    }
-}
-
-fn report_status(output: &impl Output, outcome: &Outcome, cmd: &str) {
     if outcome.is_success() {
-        output.finish_success(ModeIntent::Verify, Some(outcome.version()));
+        Ok(outcome)
     } else {
-        output.finish_failure(ModeIntent::Verify, Some(cmd));
+        Err(CargoMSRVError::SubCommandVerify(Error::VerifyFailed(
+            VerifyFailed {
+                rust_version: version.clone(),
+                source: rust_version.into_source(),
+            },
+        )))
     }
 }
 
+/// Error which can be returned if the verifier deemed the tested Rust version incompatible.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(
-        "Crate source was found to be incompatible with its MSRV '{expected_msrv}', as defined in '{manifest}'"
+        "Crate source was found to be incompatible with Rust version '{}' specified {}", .0.rust_version, .0.source
     )]
-    VerifyFailed {
-        expected_msrv: semver::Version,
-        manifest: PathBuf,
-    },
+    VerifyFailed(VerifyFailed),
+}
+
+/// Data structure which contains information about which version failed to verify, and where
+/// we obtained this version from.
+///
+/// It is combination of the Rust version which was tested for compatibility and the source which was
+/// used to find this tested Rust version.
+#[derive(Debug)]
+pub struct VerifyFailed {
+    rust_version: semver::Version,
+    source: RustVersionSource,
+}
+
+/// A combination of a bare (two- or three component) Rust version and the source which was used to
+/// locate this version.
+struct RustVersion {
+    version: BareVersion,
+    source: RustVersionSource,
+}
+
+impl RustVersion {
+    /// Obtain the rust-version from one of two sources, in order:
+    /// 1. the rust-version given to the verify subcommand, or
+    /// 2. the rust-version as specified in the Cargo manifest
+    fn try_from_config(config: &Config) -> TResult<Self> {
+        let rust_version = config.sub_command_config().verify().rust_version.as_ref();
+
+        let (version, source) = match rust_version {
+            Some(v) => Ok((v.clone(), RustVersionSource::Arg)),
+            None => {
+                let path = config.ctx().manifest_path(config)?;
+                let manifest = parse_manifest(path)?;
+
+                manifest
+                    .minimum_rust_version()
+                    .ok_or_else(|| CargoMSRVError::NoMSRVKeyInCargoToml(path.to_path_buf()))
+                    .map(|v| (v.clone(), RustVersionSource::Manifest(path.to_path_buf())))
+            }
+        }?;
+
+        Ok(Self { version, source })
+    }
+
+    /// Get the bare (two- or three component) version specifying the Rust version.
+    fn version(&self) -> &BareVersion {
+        &self.version
+    }
+
+    /// Consume the [`RustVersion`] and return its [`RustVersionSource`].
+    fn into_source(self) -> RustVersionSource {
+        self.source
+    }
+}
+
+/// Source used to obtain a Rust version for the verifier.
+#[derive(Debug, thiserror::Error)]
+enum RustVersionSource {
+    #[error("as --rust-version argument")]
+    Arg,
+
+    #[error("as MSRV in the Cargo manifest located at '{0}'")]
+    Manifest(PathBuf),
 }

--- a/tests/verify_msrv.rs
+++ b/tests/verify_msrv.rs
@@ -17,7 +17,13 @@ mod common;
 )]
 fn verify(folder: &str) {
     let folder = fixtures_path().join(folder);
-    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
+    let with_args = vec![
+        "cargo-msrv",
+        "--path",
+        folder.to_str().unwrap(),
+        "--no-user-output",
+        "verify",
+    ];
 
     let result = run_verify(
         with_args,
@@ -41,7 +47,7 @@ fn verify(folder: &str) {
 )]
 fn verify_failed_no_msrv_specified(folder: &str) {
     let folder = fixtures_path().join(folder);
-    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap()];
+    let with_args = vec!["cargo-msrv", "--path", folder.to_str().unwrap(), "verify"];
 
     let result = run_verify(
         with_args,
@@ -74,6 +80,7 @@ fn verify_success_zero_exit_code(verify_variant: &str) {
             "--manifest-path",
             &cargo_msrv_manifest,
             "--",
+            "--no-user-output",
             "--path",
             &test_subject,
             verify_variant,
@@ -109,6 +116,7 @@ fn verify_failure_non_zero_exit_code(verify_variant: &str) {
             "--manifest-path",
             &cargo_msrv_manifest,
             "--",
+            "--no-user-output",
             "--path",
             &test_subject,
             verify_variant,
@@ -138,6 +146,7 @@ fn verify_subcommand_success_with_custom_check_cmd() {
             "--manifest-path",
             &cargo_msrv_manifest,
             "--",
+            "--no-user-output",
             "--path",
             &test_subject,
             "verify",
@@ -156,4 +165,25 @@ fn verify_subcommand_success_with_custom_check_cmd() {
     let expected = ExitCode::Success;
 
     assert_eq!(exit_code, Into::<i32>::into(expected));
+}
+
+#[test]
+fn verify_with_rust_version_opt() {
+    let version = "1.37.0";
+    let folder = fixtures_path().join(version);
+    let with_args = vec![
+        "cargo-msrv",
+        "--path",
+        folder.to_str().unwrap(),
+        "verify",
+        "--rust-version",
+        version,
+    ];
+
+    let result = run_verify(
+        with_args,
+        vec![Release::new_stable(semver::Version::new(1, 37, 0))],
+    );
+
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
Previously the rust-version (MSRV) could only be verified if it was set in the Cargo manifest. This required projects using older versions to use the non-standard package.metadata.msrv field. In addition, it required projects where we just want to run verify once or twice, to set the version temporarily in the Cargo manifest.
Now this is no longer required, as one can instead simply run cargo verify --rust-version <ARG>. The argument will be prioritized over the version specified in the Cargo manifest.

NB: The deprecated cargo `msrv --verify` does not support this option. The dedicated `cargo msrv verify` subcommand must be used.