### PR TITLE
Rename toolchain-file flag to write-toolchain-file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 
 ### Changed
 
-* CLI options are now grouped by option types
+* CLI options are now grouped by option types.
 * Option `--min <version>` now also accepts two component semver major.minor versions, in addition to full three component (strict) SemVer versions, and edition specifiers like "2015", "2018" and "2021".
 * Option `--max <version>` now also accepts two component semver major.minor versions, in addition to full three component (strict) SemVer versions.
 * The rust-releases index is now only fetched when running subcommands require it.
+* Renamed `--toolchain-file` to `--write-toolchain-file` to emphasise the toolchain being an output.
 
 ### Fixed
 

--- a/book/src/commands/find.md
+++ b/book/src/commands/find.md
@@ -149,7 +149,7 @@ is incorrect.
 
 Supply a custom target triplet to use as Rust distribution. If absent, the rustup default toolchain is used.
 
-**`--toolchain-file`**
+**`--write-toolchain-file`**
 
 Output a rust-toolchain file with the determined MSRV as toolchain. The toolchain file will pin the Rust version for this crate. 
 See [here](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) for more about the toolchain-file.

--- a/src/cli/configurators/output_toolchain_file.rs
+++ b/src/cli/configurators/output_toolchain_file.rs
@@ -10,6 +10,6 @@ impl Configure for OutputToolchainFile {
         builder: ConfigBuilder<'c>,
         opts: &'c CargoMsrvOpts,
     ) -> TResult<ConfigBuilder<'c>> {
-        Ok(builder.output_toolchain_file(opts.find_opts.toolchain_file))
+        Ok(builder.output_toolchain_file(opts.find_opts.write_toolchain_file))
     }
 }

--- a/src/cli/find_opts.rs
+++ b/src/cli/find_opts.rs
@@ -22,12 +22,12 @@ pub struct FindOpts {
     #[clap(long, conflicts_with = "bisect")]
     pub linear: bool,
 
-    /// Output a rust-toolchain file with the MSRV as toolchain
+    /// Pin the MSRV by writing the version to a rust-toolchain file
     ///
     /// The toolchain file will pin the Rust version for this crate.
     /// See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file for more.
-    #[clap(long)]
-    pub toolchain_file: bool,
+    #[clap(long, alias = "toolchain-file")]
+    pub write_toolchain_file: bool,
 
     /// Temporarily remove the lockfile, so it will not interfere with the building process
     ///


### PR DESCRIPTION
This makes it more clear that the behaviour invoked by setting the flag will (over)write the toolchain file, instead of reading from it.
The original handle is kept as an alias.