### PR TITLE
Fix bug where reading MSRV from inline table was not possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 ### Fixed
 
 * Subcommand `cargo msrv set` will now return an error when the Cargo manifest contains a virtual workspace.
-* The program will no longer return an unformatted message when a command failed and the output format was set to json. 
+* The program will no longer return an unformatted message when a command failed and the output format was set to json.
+* Fix issue where reading the fallback MSRV from a TOML inline table was not possible
 
 [Unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.15.1...HEAD
 


### PR DESCRIPTION
closes #360

However, we should also insert a regular table by default, as the inline table will not allow users to add other [metadata] keys (manually, if entries already exist, we use the existing table instead of creating a new one; i.e. in that case this bug did not exist).