### PR TITLE
Default to creating a regular TOML table for the metadata MSRV fallback value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 * Option `--max <version>` now also accepts two component semver major.minor versions, in addition to full three component (strict) SemVer versions.
 * The rust-releases index is now only fetched when running subcommands require it.
 * Renamed `--toolchain-file` to `--write-toolchain-file` to emphasise the toolchain being an output.
+* Subcommand `cargo msrv set` will now default to writing a regular TOML table for the metadata MSRV fallback value, instead of an inline table.
 
 ### Fixed
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -88,6 +88,9 @@ pub enum CargoMSRVError {
     SemverError(#[from] rust_releases::semver::Error),
 
     #[error(transparent)]
+    SetMsrv(#[from] SetMsrvError),
+
+    #[error(transparent)]
     SubCommandVerify(#[from] verify::Error),
 
     #[error(transparent)]
@@ -161,4 +164,12 @@ pub enum IoErrorSource {
 
     #[error("Unable to collect output from '{0:?}', or process did not terminate properly")]
     WaitForProcessAndCollectOutput(OsString),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SetMsrvError {
+    #[error(
+        "Unable to set the MSRV in the 'package.metadata' table: 'package.metadata' is not a table"
+    )]
+    NotATable,
 }


### PR DESCRIPTION
Previously we would create an inline table instead, but the inline table makes it harder to add more values (as keys and values need to be on one line).

closes #364 