### PR TITLE
 Fix an out-of-bounds panic which occurred if the filtered search space was empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 * Subcommand `cargo msrv set` will now return an error when the Cargo manifest solely consists of a virtual workspace.
 * The program will no longer return an unformatted message when a command failed and the output format was set to json.
 * Fix issue where reading the fallback MSRV from a TOML inline table was not possible.
+* Fix an index out-of-bounds panic which occurred if the filtered Rust releases search space was empty
 
 [Unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.15.1...HEAD
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,9 +363,9 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bisector"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bbf0ee6b0721f6eafe0ca87f8d9113bb5854f418a07676be89146f2428843a"
+checksum = "dfeef1147df76ec07ed65ac0f7db05f4fa8617acde06dd8a4b3c703bf8f83d6f"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ comfy-table = "5.0.1"
 once_cell = "1.12.0"
 thiserror = "1.0.31"
 
-bisector = "0.3.0"
+bisector = "0.4.0"
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/src/subcommands/find/tests.rs
+++ b/src/subcommands/find/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::config::ConfigBuilder;
+use crate::manifest::bare_version::BareVersion;
 use crate::testing::{Record, TestResultReporter, TestRunner};
 use rust_releases::semver;
 use std::iter::FromIterator;
@@ -117,4 +119,47 @@ fn bisect_none_compatible() {
             Record::CmdWasFailure,
         ]
     );
+}
+
+// https://github.com/foresterre/cargo-msrv/issues/369
+#[test]
+fn no_releases_available() {
+    let releases = vec![
+        Release::new_stable(semver::Version::new(1, 46, 0)),
+        Release::new_stable(semver::Version::new(1, 55, 0)),
+        Release::new_stable(semver::Version::new(1, 56, 0)),
+        Release::new_stable(semver::Version::new(1, 57, 0)),
+        Release::new_stable(semver::Version::new(1, 58, 1)),
+        Release::new_stable(semver::Version::new(1, 59, 0)),
+    ];
+
+    let index = ReleaseIndex::from_iter(releases.clone());
+
+    let min = BareVersion::TwoComponents(1, 56);
+    let max = BareVersion::ThreeComponents(1, 54, 0);
+
+    // Make sure we end up with an empty releases set
+    let config = ConfigBuilder::new(ModeIntent::Find, "")
+        .minimum_version(min.clone()) // i.e. Rust edition = 2021
+        .maximum_version(max.clone())
+        .build();
+
+    let reporter = TestResultReporter::default();
+    let runner = TestRunner::with_ok(releases.iter().map(|r| r.version()));
+
+    let cmd = Find::new(&index, runner);
+    let result = cmd.run(&config, &reporter);
+
+    let err = result.unwrap_err();
+
+    assert!(matches!(err, CargoMSRVError::NoToolchainsToTry(_)));
+
+    if let CargoMSRVError::NoToolchainsToTry(inner_err) = err {
+        assert_eq!(inner_err.min.as_ref(), Some(&min));
+        assert_eq!(inner_err.max.as_ref(), Some(&max));
+        assert_eq!(&inner_err.search_space, &[]);
+    }
+
+    let log = reporter.log();
+    assert_eq!(log.as_slice(), []);
 }


### PR DESCRIPTION
This panic happened because we initialized the Indices with invalid values: when search space would be empty (i.e. have len = 0), the Indices would be initialized with (lhs: 0, rhs: len - 1). Since len was 0, rhs would underflow in rustc release mode (and panic in rustc debug mode). In rustc release mode, this would cause a panic during the bisection, since the cursor of the bisector would point to a value around half the size of usize::MAX.

We fix this issue by ensuring we'll always build a valid Indices instance, via Bisector's new Indices::try_from_bisector fallible initialization method.

closes #369