### PR TITLE
Put output-format before verify in GitHub Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,4 +155,4 @@ jobs:
       - name: version_of_cargo_msrv
         run: cargo msrv --version # as of writing: 0.14.0 (required for verify)
       - name: run_cargo_msrv
-        run: cargo msrv verify --output-format json | jsonlines-tail | jq --exit-status .success
+        run: cargo msrv --output-format json verify | jsonlines-tail | jq --exit-status .success


### PR DESCRIPTION
Having `verify` before `--output-format` causes the following error:

    error: Found argument '--output-format' which wasn't expected, or isn't valid in this context