### PR TITLE
Add 'minimal' output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
   which can be used to check for a crate's compatibility against a specific Rust version. 
 * Added flag `--write-msrv` to cargo msrv (find), which upon finding the MSRV writes its value to the Cargo manifest.
 * Added option to refer to a specific crate using its Cargo manifest (with `--manifest-path`) instead of its path (with `--path`)
+* Added a 'minimal' output option intended for machine-readable use when full json output is undesirable.
 
 ### Changed
 
@@ -24,7 +25,7 @@ the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a 
 * The rust-releases index is now only fetched for subcommands which depend on it.
 * Renamed `--toolchain-file` to `--write-toolchain-file` to emphasise that the toolchain-file is an output.
 * Subcommand `cargo msrv set` will now default to writing a regular TOML table for the metadata MSRV fallback value, instead of an inline table.
-* The rust-toolchain file will now be overwritten if a rust-toolchain file was already present
+* The rust-toolchain file will now be overwritten if a rust-toolchain file was already present.
 
 ### Fixed
 

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -6,7 +6,12 @@
   - [Quick Start](./getting-started/quick-start.md)
 
 - [Concepts](./concepts/index.md)
-- [Cargo-msrv Commands](./commands/index.md)
+- [Output Formats](output-formats/index.md)
+  - [human](output-formats/human.md)
+  - [json](output-formats/json.md)
+  - [minimal](output-formats/minimal.md)
+  - [no-user-output](output-formats/no-user-output.md)
+- [Commands](./commands/index.md)
   - [cargo-msrv](./commands/find.md) 
   - [cargo-msrv help](./commands/help.md) 
   - [cargo-msrv list](./commands/list.md) 

--- a/book/src/getting-started/index.md
+++ b/book/src/getting-started/index.md
@@ -1,4 +1,4 @@
-## Getting started with cargo-msrv
+# Getting started with cargo-msrv
 
 * [Installation](installation.md)
 * [Quick Start](quick-start.md)

--- a/book/src/output-formats/human.md
+++ b/book/src/output-formats/human.md
@@ -1,0 +1,3 @@
+# Output format: human
+
+🚧 TODO 🚧

--- a/book/src/output-formats/index.md
+++ b/book/src/output-formats/index.md
@@ -1,0 +1,32 @@
+# Output formats
+
+In `cargo-msrv` we to status of the program is reported via events. These events are issued at several stages of the
+program execution. As a user of `cargo-msrv`, you may choose how these events are formatted into a human-readable
+or machine-readable representation. User output may also be disabled altogether.
+
+The next section gives an overview of the supported representations. Thereafter, you may find an index to
+the chapters which detail each representation.
+
+## Choosing an output format
+
+The first output format is the `human` output format. As the name suggests,
+its output is meant to be interpreted by humans, and consists of elaborate colouring and
+custom styling.
+
+The second output format is the `json` output format. This is a detailed machine-readable
+format and also the format which most closely mimics the events as they are reported internally.
+Events are printed in a `json-lines` (`jsonl`) format to *stderr*.
+
+The third output-format is the `minimal` output format. This format is intended to be used by shell scripts
+or programs which do not require detailed output. Its format does not require complex parsing, and only
+reports the final results of commands.
+
+The fourth option is to not print any user output. This is uncommon, but may be used in conjunction with
+printing debug (i.e. developer) output only, so the debug output is not overwritten by the user output.
+
+## The output formats
+
+* [human](human.md) (default)
+* [json](json.md)
+* [minimal](minimal.md)
+* [no-user-output](no-user-output.md)

--- a/book/src/output-formats/json.md
+++ b/book/src/output-formats/json.md
@@ -1,0 +1,3 @@
+# Output format: json
+
+🚧 TODO 🚧

--- a/book/src/output-formats/minimal.md
+++ b/book/src/output-formats/minimal.md
@@ -5,8 +5,10 @@ to be understandable, while not requiring elaborate parsers like the `json` outp
 a minimal human-readable format.
 
 This output format can be summarized by the following two statements:
-* If the command was successful, it prints the commands final result and exits with a zero exit code
-* If the command was unsuccessful, it prints an error message, and exits with a non-zero exit code
+* If the command was successful, it prints the commands final result and exits with a zero exit code. Output is printed
+  to `stdout`.
+* If the command was unsuccessful, it prints an error message, and exits with a non-zero exit code. Output is printed  
+  to `stderr`.
 
 You may also refer to the 🚧 TODO 🚧 section to determine which kind of errors result in a non-zero
 exit code, and how different errors are categorised.
@@ -15,8 +17,8 @@ exit code, and how different errors are categorised.
 
 ## \# cargo msrv (find)
 
-If the MSRV was found, we report this minimal supported Rust version.
-If it could not be found, we report `none` instead.
+If the MSRV was found, we report this minimal supported Rust version by writing it to `stdout`.
+If it could not be found, we report `none` instead, and write this value to `stderr`.
 
 ### Example 1
 
@@ -24,17 +26,17 @@ If the MSRV is `1.60.0`, the output will be just `1.60.0`.
 
 ```shell
 cargo msrv --output-format minimal
-# 1.60.0
+#stdout: 1.60.0
 ```
 
 ### Example 2
 
 If the MSRV can't be found, for example if your project requires a nightly compiler feature
-or has incorrect syntax, the output will be just `none`. 
+or has incorrect syntax, the output will be `none`. 
 
 ```shell
 cargo msrv --output-format minimal
-# none
+#stderr: none
 ```
 
 ## \# cargo msrv list
@@ -53,7 +55,7 @@ If we set our MSRV to be `1.31`, the output will be `1.31`.
 
 ```shell
 cargo msrv --output-format minimal set 1.31
-# 1.31
+#stdout: 1.31
 ```
 
 ## \# cargo msrv show
@@ -75,7 +77,7 @@ rust-version = "1.60"
 
 ```shell
 cargo msrv --output-format minimal show
-# 1.60
+#stdout: 1.60
 ```
 
 ### Example 2
@@ -96,5 +98,5 @@ msrv = "1.21.0"
 
 ```shell
 cargo msrv --output-format minimal show
-# 1.21.0
+#stdout: 1.21.0
 ```

--- a/book/src/output-formats/minimal.md
+++ b/book/src/output-formats/minimal.md
@@ -1,0 +1,100 @@
+# Output format: minimal
+
+The purpose of the `minimal` output format option is to provide just enough output for a machine (or shell script!)
+to be understandable, while not requiring elaborate parsers like the `json` output format. It may also be used as
+a minimal human-readable format.
+
+This output format can be summarized by the following two statements:
+* If the command was successful, it prints the commands final result and exits with a zero exit code
+* If the command was unsuccessful, it prints an error message, and exits with a non-zero exit code
+
+You may also refer to the 🚧 TODO 🚧 section to determine which kind of errors result in a non-zero
+exit code, and how different errors are categorised.
+
+# Output by subcommand
+
+## \# cargo msrv (find)
+
+If the MSRV was found, we report this minimal supported Rust version.
+If it could not be found, we report `none` instead.
+
+### Example 1
+
+If the MSRV is `1.60.0`, the output will be just `1.60.0`. 
+
+```shell
+cargo msrv --output-format minimal
+# 1.60.0
+```
+
+### Example 2
+
+If the MSRV can't be found, for example if your project requires a nightly compiler feature
+or has incorrect syntax, the output will be just `none`. 
+
+```shell
+cargo msrv --output-format minimal
+# none
+```
+
+## \# cargo msrv list
+
+The `list` subcommand is not supported by the `minimal` output format, and "unsupported" will be printed.
+Support may be added in the future.
+
+
+## \# cargo msrv set
+
+The `set` subcommand prints the version set as MSRV.
+
+### Example 1
+
+If we set our MSRV to be `1.31`, the output will be `1.31`.
+
+```shell
+cargo msrv --output-format minimal set 1.31
+# 1.31
+```
+
+## \# cargo msrv show
+
+The `show` subcommand prints the detected MSRV, if specified in the Cargo Manifest.
+
+### Example 1
+
+Assuming our Cargo manifest contains a `1.60` MSRV, `cargo-msrv` will print `1.60`.
+
+**Cargo.toml**
+
+```toml
+[package]
+rust-version = "1.60"
+```
+
+**Shell**
+
+```shell
+cargo msrv --output-format minimal show
+# 1.60
+```
+
+### Example 2
+
+Assuming our Cargo manifest lists the MSRV in the `package.metadata.msrv` field, `cargo-msrv` will print `1.21.0`.
+The `package.rust-version` field has precedence over the `package.metadata.msrv`. You may see the `package.metadata.msrv`
+key for crates which use a Cargo version which does not yet support the `package.rust-version` field. `cargo-msrv`
+supports both fields.
+
+**Cargo.toml**
+
+```toml
+[package.metadata]
+msrv = "1.21.0"
+```
+
+**Shell**
+
+```shell
+cargo msrv --output-format minimal show
+# 1.21.0
+```

--- a/book/src/output-formats/no-user-output.md
+++ b/book/src/output-formats/no-user-output.md
@@ -1,0 +1,4 @@
+# Output format: no-user-output
+
+The 'no-user-output' is not really a "user output" variant. Choosing this option disables user output of events
+altogether. Disabling the user output may be achieved by providing the `--no-user-output` flag.

--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -99,7 +99,7 @@ fn get_exit_code(
 enum WrappingHandler {
     HumanProgress(HumanProgressHandler),
     Json(JsonHandler<io::Stderr>),
-    Minimal(MinimalOutputHandler<io::Stderr>),
+    Minimal(MinimalOutputHandler<io::Stdout, io::Stderr>),
     DiscardOutput(DiscardOutputHandler),
 }
 

--- a/src/check/rustup_toolchain_check.rs
+++ b/src/check/rustup_toolchain_check.rs
@@ -3,7 +3,7 @@ use crate::command::RustupCommand;
 use crate::download::{DownloadToolchain, ToolchainDownloader};
 use crate::error::IoErrorSource;
 use crate::lockfile::{LockfileHandler, CARGO_LOCK};
-use crate::reporter::event::{CheckToolchain, Compatibility, CompatibilityCheckMethod, Method};
+use crate::reporter::event::{CheckMethod, CheckResult, CheckToolchain, Method};
 use crate::toolchain::ToolchainSpec;
 use crate::{CargoMSRVError, Config, Outcome, Reporter, TResult};
 use once_cell::unsync::OnceCell;
@@ -78,7 +78,7 @@ impl<'reporter, R: Reporter> RustupToolchainCheck<'reporter, R> {
         let mut cmd: Vec<&str> = vec![toolchain.spec()];
         cmd.extend_from_slice(check);
 
-        self.reporter.report_event(CompatibilityCheckMethod::new(
+        self.reporter.report_event(CheckMethod::new(
             toolchain.to_owned(),
             Method::rustup_run(&cmd, dir),
         ))?;
@@ -117,18 +117,18 @@ impl<'reporter, R: Reporter> RustupToolchainCheck<'reporter, R> {
             Outcome::Success(outcome) => {
                 // report compatibility with this toolchain
                 self.reporter
-                    .report_event(Compatibility::compatible(outcome.toolchain_spec.to_owned()))?
+                    .report_event(CheckResult::compatible(outcome.toolchain_spec.to_owned()))?
             }
             Outcome::Failure(outcome) if no_error_report => {
                 // report incompatibility with this toolchain
-                self.reporter.report_event(Compatibility::incompatible(
+                self.reporter.report_event(CheckResult::incompatible(
                     outcome.toolchain_spec.to_owned(),
                     None,
                 ))?
             }
             Outcome::Failure(outcome) => {
                 // report incompatibility with this toolchain
-                self.reporter.report_event(Compatibility::incompatible(
+                self.reporter.report_event(CheckResult::incompatible(
                     outcome.toolchain_spec.to_owned(),
                     Some(outcome.error_message.clone()),
                 ))?

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,8 @@ pub enum OutputFormat {
     Human,
     /// Json status updates printed to stdout
     Json,
+    /// Minimal output, usually just the result, such as the MSRV or whether verify succeeded or failed
+    Minimal,
     /// No output -- meant to be used for debugging and testing
     None,
 }
@@ -40,6 +42,7 @@ impl fmt::Display for OutputFormat {
         match self {
             Self::Human => write!(f, "human"),
             Self::Json => write!(f, "json"),
+            Self::Minimal => write!(f, "minimal"),
             Self::None => write!(f, "none"),
         }
     }
@@ -52,6 +55,7 @@ impl FromStr for OutputFormat {
         match s {
             "human" => Ok(Self::Human),
             "json" => Ok(Self::Json),
+            "minimal" => Ok(Self::Minimal),
             unknown => Err(CargoMSRVError::InvalidConfig(format!(
                 "Given output format '{}' is not valid",
                 unknown
@@ -61,24 +65,14 @@ impl FromStr for OutputFormat {
 }
 
 impl OutputFormat {
+    pub const HUMAN: &'static str = "human";
     pub const JSON: &'static str = "json";
+    pub const MINIMAL: &'static str = "minimal";
 
     /// A set of formats which may be given as a configuration option
     ///   through the CLI.
     pub fn custom_formats() -> &'static [&'static str] {
-        &["human", Self::JSON]
-    }
-
-    /// Parse the output format from the given `&str`.
-    ///
-    /// **Panics**
-    ///
-    /// Panics if the format is not known, or can not be set by a user.
-    pub fn from_custom_format_str(item: &str) -> Self {
-        match item {
-            Self::JSON => Self::Json,
-            _ => unreachable!(),
-        }
+        &[Self::HUMAN, Self::JSON, Self::MINIMAL]
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,8 @@
+use std::io;
+
+pub trait SendWriter: io::Write + Send + 'static {}
+
+impl SendWriter for io::Stderr {}
+
+#[cfg(test)]
+impl SendWriter for Vec<u8> {}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,6 +1,9 @@
 use std::io;
 
-pub trait SendWriter: io::Write + Send + 'static {}
+// Alias trait for Write + Send
+pub trait SendWriter: io::Write + Send {}
+
+impl SendWriter for io::Stdout {}
 
 impl SendWriter for io::Stderr {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod cli;
 pub mod config;
 pub mod error;
 pub mod exit_code;
+pub mod io;
 pub mod reporter;
 pub mod toolchain;
 

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -6,6 +6,7 @@ use crate::TResult;
 pub use handler::DiscardOutputHandler;
 pub use handler::HumanProgressHandler;
 pub use handler::JsonHandler;
+pub use handler::MinimalOutputHandler;
 
 pub use event::{
     Event, Message,

--- a/src/reporter/event.rs
+++ b/src/reporter/event.rs
@@ -18,6 +18,7 @@ pub use set_output::SetOutputMessage;
 pub use setup_toolchain::SetupToolchain;
 pub use show_output::ShowOutputMessage;
 pub use termination::TerminateWithFailure;
+pub use verify_output::VerifyOutput;
 
 mod action;
 mod auxiliary_output;
@@ -34,6 +35,7 @@ mod set_output;
 mod setup_toolchain;
 mod show_output;
 mod termination;
+mod verify_output;
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -102,6 +104,7 @@ pub enum Message {
 
     // command: verify
     // Verify
+    Verify(VerifyOutput),
 
     // command: list
     ListDep(ListDep),

--- a/src/reporter/event.rs
+++ b/src/reporter/event.rs
@@ -1,13 +1,17 @@
 use std::fmt;
 use std::fmt::Formatter;
 
+// shared
+pub use shared::compatibility::{Compatibility, CompatibilityReport};
+
+// events
 pub use action::ActionMessage;
 pub use auxiliary_output::{
     AuxiliaryOutput, Destination, Item as AuxiliaryOutputItem, MsrvKind, ToolchainFileKind,
 };
+pub use check_method::{CheckMethod, Method};
+pub use check_result::CheckResult;
 pub use check_toolchain::CheckToolchain;
-pub use compatibility::{Compatibility, CompatibilityReport};
-pub use compatibility_check_method::{CompatibilityCheckMethod, Method};
 pub use fetch_index::FetchIndex;
 pub use list_dep::ListDep;
 pub use meta::Meta;
@@ -20,11 +24,15 @@ pub use show_output::ShowOutputMessage;
 pub use termination::TerminateWithFailure;
 pub use verify_output::VerifyOutput;
 
+// shared
+mod shared;
+
+// specific events
 mod action;
 mod auxiliary_output;
+mod check_method;
+mod check_result;
 mod check_toolchain;
-mod compatibility;
-mod compatibility_check_method;
 mod fetch_index;
 mod list_dep;
 mod meta;
@@ -91,8 +99,8 @@ pub enum Message {
 
     // runner + pass/reject
     CheckToolchain(CheckToolchain),
-    CompatibilityCheckMethod(CompatibilityCheckMethod),
-    Compatibility(Compatibility),
+    CompatibilityCheckMethod(CheckMethod),
+    Compatibility(CheckResult),
 
     // output written by the program
     AuxiliaryOutput(AuxiliaryOutput),

--- a/src/reporter/event/check_method.rs
+++ b/src/reporter/event/check_method.rs
@@ -5,12 +5,12 @@ use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub struct CompatibilityCheckMethod {
+pub struct CheckMethod {
     toolchain: OwnedToolchainSpec,
     method: Method,
 }
 
-impl CompatibilityCheckMethod {
+impl CheckMethod {
     pub fn new(toolchain: impl Into<OwnedToolchainSpec>, method: Method) -> Self {
         Self {
             toolchain: toolchain.into(),
@@ -19,8 +19,8 @@ impl CompatibilityCheckMethod {
     }
 }
 
-impl From<CompatibilityCheckMethod> for Event {
-    fn from(it: CompatibilityCheckMethod) -> Self {
+impl From<CheckMethod> for Event {
+    fn from(it: CheckMethod) -> Self {
         Message::CompatibilityCheckMethod(it).into()
     }
 }
@@ -63,7 +63,7 @@ mod tests {
     )]
     fn reported_event(method: Method) {
         let reporter = TestReporter::default();
-        let event = CompatibilityCheckMethod::new(
+        let event = CheckMethod::new(
             OwnedToolchainSpec::new(&semver::Version::new(1, 2, 3), "test_target"),
             method,
         );

--- a/src/reporter/event/shared.rs
+++ b/src/reporter/event/shared.rs
@@ -1,0 +1,2 @@
+/// Event context which is shared between several events
+pub mod compatibility;

--- a/src/reporter/event/shared/compatibility.rs
+++ b/src/reporter/event/shared/compatibility.rs
@@ -1,0 +1,60 @@
+use crate::toolchain::OwnedToolchainSpec;
+
+/// Reports whether a crate is compatible with a certain toolchain, or not.
+/// If it's not compatible, it may specify a reason why it is not compatible.
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Compatibility {
+    toolchain: OwnedToolchainSpec,
+    decision: bool,
+    compatibility_report: CompatibilityReport,
+}
+
+impl Compatibility {
+    pub fn compatible(toolchain: impl Into<OwnedToolchainSpec>) -> Self {
+        Self {
+            toolchain: toolchain.into(),
+            decision: true,
+            compatibility_report: CompatibilityReport::Compatible,
+        }
+    }
+
+    pub fn incompatible(toolchain: impl Into<OwnedToolchainSpec>, error: Option<String>) -> Self {
+        Self {
+            toolchain: toolchain.into(),
+            decision: false,
+            compatibility_report: CompatibilityReport::Incompatible {
+                error: error.map(Into::into),
+            },
+        }
+    }
+
+    pub fn toolchain(&self) -> &OwnedToolchainSpec {
+        &self.toolchain
+    }
+
+    pub fn is_compatible(&self) -> bool {
+        self.decision
+    }
+
+    pub fn compatibility_report(&self) -> &CompatibilityReport {
+        &self.compatibility_report
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompatibilityReport {
+    Compatible,
+    Incompatible { error: Option<String> },
+}
+
+impl CompatibilityReport {
+    pub fn error(&self) -> Option<&str> {
+        match self {
+            Self::Compatible => None,
+            Self::Incompatible { error } => error.as_deref(),
+        }
+    }
+}

--- a/src/reporter/event/verify_output.rs
+++ b/src/reporter/event/verify_output.rs
@@ -1,0 +1,97 @@
+use crate::reporter::event::Message;
+use crate::toolchain::OwnedToolchainSpec;
+use crate::Event;
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct VerifyOutput {
+    pub toolchain: OwnedToolchainSpec,
+    /// True if compatible, false if incompatible
+    decision: bool,
+    pub compatibility_report: CompatibilityReport,
+}
+
+impl VerifyOutput {
+    pub fn compatible(toolchain: impl Into<OwnedToolchainSpec>) -> Self {
+        Self {
+            toolchain: toolchain.into(),
+            decision: true,
+            compatibility_report: CompatibilityReport::Compatible,
+        }
+    }
+
+    pub fn incompatible(toolchain: impl Into<OwnedToolchainSpec>, error: Option<String>) -> Self {
+        Self {
+            toolchain: toolchain.into(),
+            decision: false,
+            compatibility_report: CompatibilityReport::Incompatible {
+                error: error.map(Into::into),
+            },
+        }
+    }
+
+    pub fn toolchain(&self) -> &OwnedToolchainSpec {
+        &self.toolchain
+    }
+
+    pub fn is_compatible(&self) -> bool {
+        self.decision
+    }
+}
+
+impl From<VerifyOutput> for Event {
+    fn from(it: VerifyOutput) -> Self {
+        Message::Verify(it).into()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompatibilityReport {
+    Compatible,
+    Incompatible { error: Option<String> },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reporter::event::Message;
+    use crate::reporter::TestReporter;
+    use crate::{semver, Event};
+    use storyteller::Reporter;
+
+    #[test]
+    fn reported_compatible_toolchain() {
+        let reporter = TestReporter::default();
+        let event = VerifyOutput::compatible(OwnedToolchainSpec::new(
+            &semver::Version::new(1, 2, 3),
+            "test_target",
+        ));
+
+        reporter.reporter().report_event(event.clone()).unwrap();
+
+        assert_eq!(
+            reporter.wait_for_events(),
+            vec![Event::new(Message::Verify(event)),]
+        );
+    }
+
+    #[yare::parameterized(
+        none = { None },
+        some = { Some("whoo!".to_string()) },
+    )]
+    fn reported_incompatible_toolchain(error_message: Option<String>) {
+        let reporter = TestReporter::default();
+        let event = VerifyOutput::incompatible(
+            OwnedToolchainSpec::new(&semver::Version::new(1, 2, 3), "test_target"),
+            error_message,
+        );
+
+        reporter.reporter().report_event(event.clone()).unwrap();
+
+        assert_eq!(
+            reporter.wait_for_events(),
+            vec![Event::new(Message::Verify(event)),]
+        );
+    }
+}

--- a/src/reporter/handler.rs
+++ b/src/reporter/handler.rs
@@ -10,6 +10,7 @@ use storyteller::{EventHandler, Reporter};
 mod discard_output_handler;
 mod human_progress_handler;
 mod json_handler;
+mod minimal_output_handler;
 
 #[cfg(test)]
 mod testing;
@@ -17,6 +18,7 @@ mod testing;
 pub use discard_output_handler::DiscardOutputHandler;
 pub use human_progress_handler::HumanProgressHandler;
 pub use json_handler::JsonHandler;
+pub use minimal_output_handler::MinimalOutputHandler;
 
 #[cfg(test)]
 pub use testing::TestingHandler;

--- a/src/reporter/handler/human_progress_handler.rs
+++ b/src/reporter/handler/human_progress_handler.rs
@@ -1,6 +1,6 @@
 use crate::formatting::TermWidth;
 use crate::reporter::event::{
-    CheckToolchain, Compatibility, CompatibilityReport, Message, MsrvResult,
+    CheckResult, CheckToolchain, CompatibilityReport, Message, MsrvResult,
 };
 use crate::{semver, Action, Event};
 use owo_colors::OwoColorize;
@@ -82,17 +82,18 @@ impl EventHandler for HumanProgressHandler {
                 let version = it.toolchain.version();
                 self.finish_runner_progress();
             }
-            Message::Compatibility(Compatibility {  compatibility_report: CompatibilityReport::Compatible, toolchain, .. }) => {
-                let version = toolchain.version();
+            // Message::Compatibility(CheckResult {  compatibility_report: CompatibilityReport::Compatible, toolchain, .. }) => {
+            Message::Compatibility(CheckResult {  compatibility }) if compatibility.is_compatible() => {
+                let version = compatibility.toolchain().version();
                 let message = Status::ok("Is compatible");
                 self.pb.println(message);
             }
-            Message::Compatibility(Compatibility {  compatibility_report: CompatibilityReport::Incompatible { error }, toolchain, .. }) => {
-                let version = toolchain.version();
+            Message::Compatibility(CheckResult { compatibility }) if !compatibility.is_compatible() => {
+                let version = compatibility.toolchain().version();
                 let message = Status::fail("Is Incompatible");
                 self.pb.println(message);
 
-                if let Some(error_report) = error.as_deref() {
+                if let Some(error_report) = compatibility.compatibility_report().error() {
                     self.pb.println(message_box(error_report));
                 }
             }

--- a/src/reporter/handler/json_handler.rs
+++ b/src/reporter/handler/json_handler.rs
@@ -1,9 +1,8 @@
+use crate::io::SendWriter;
 use std::io;
 use std::io::Stderr;
 use std::sync::{Arc, Mutex};
 use storyteller::EventHandler;
-
-pub trait SendWriter: io::Write + Send + 'static {}
 
 pub struct JsonHandler<W: SendWriter> {
     writer: Arc<Mutex<W>>,
@@ -17,8 +16,6 @@ impl<W: SendWriter> JsonHandler<W> {
     const WRITE_FAILURE_MSG: &'static str =
         "{ \"panic\": true, \"cause\": \"Unable to write serialized event for JsonHandle\", \"experimental\": true }";
 }
-
-impl SendWriter for Stderr {}
 
 impl JsonHandler<Stderr> {
     pub fn stderr() -> Self {

--- a/src/reporter/handler/minimal_output_handler.rs
+++ b/src/reporter/handler/minimal_output_handler.rs
@@ -1,0 +1,274 @@
+use crate::io::SendWriter;
+use crate::reporter::Message;
+use crate::Action;
+use std::cell::Cell;
+use std::io;
+use std::io::{Stderr, Stdout};
+use std::sync::{Arc, Mutex, MutexGuard};
+use storyteller::EventHandler;
+
+/// An output handler which reports just some minimal results.
+///
+/// It can be used when machine parsing is used, but parsing json would be too much work
+/// or there is no desire for the extended output which can be found in the json output.
+// Consider: lock stderr for the process, and use writeln!(self.stderr, "{}", ...);
+#[derive(Debug)]
+pub struct MinimalOutputHandler<W: SendWriter> {
+    writer: Arc<Mutex<W>>,
+}
+
+impl<W: SendWriter> MinimalOutputHandler<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            writer: Arc::new(Mutex::new(writer)),
+        }
+    }
+}
+
+impl MinimalOutputHandler<Stderr> {
+    pub fn stderr() -> Self {
+        Self {
+            writer: Arc::new(Mutex::new(io::stderr())),
+        }
+    }
+}
+
+#[cfg(test)]
+impl<W: SendWriter> MinimalOutputHandler<W> {
+    fn inner(&self) -> MutexGuard<'_, W> {
+        self.writer.lock().expect("Unable to lock writer")
+    }
+}
+
+impl<W: SendWriter> EventHandler for MinimalOutputHandler<W> {
+    type Event = super::Event;
+
+    fn handle(&self, event: Self::Event) {
+        use std::io::Write;
+
+        // Early return when message is not a final result message.
+        // Also ensures we don't unnecessarily lock the writer.
+        if !event.message().is_final_result() {
+            return;
+        }
+
+        let mut writer = self.writer.lock().expect("Unable to lock writer");
+
+        match event.message() {
+            // cargo msrv (find)
+            Message::MsrvResult(find) => match find.msrv() {
+                Some(v) => writeln!(&mut writer, "{}", v),
+                None => writeln!(&mut writer, "none"),
+            },
+            // cargo msrv list
+            // Consider: simplify output for this command, if you want the full output you can use
+            //           the default human output mode
+            //           for now: unsupported
+            Message::ListDep(list) => {
+                writeln!(&mut writer, "unsupported")
+            }
+            // cargo msrv set output
+            Message::SetOutput(set) => {
+                writeln!(&mut writer, "{}", set.version())
+            }
+            // cargo msrv show
+            Message::ShowOutput(show) => {
+                writeln!(&mut writer, "{}", show.version())
+            } // cargo msrv verify
+            Message::Verify(verify) => {
+                writeln!(&mut writer, "{}", verify.is_compatible())
+            }
+            // If not a final result, discard
+            _ => {
+                unreachable!("Early return missing, see `Message::is_final_result`.")
+            }
+        };
+    }
+}
+
+impl Message {
+    fn is_final_result(&self) -> bool {
+        matches!(
+            &self,
+            Message::MsrvResult(_)
+                | Message::ListDep(_)
+                | Message::SetOutput(_)
+                | Message::SetOutput(_)
+                | Message::ShowOutput(_)
+                | Message::Verify(_)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::list::ListMsrvVariant;
+    use crate::dependency_graph::DependencyGraph;
+    use crate::manifest::bare_version::BareVersion;
+    use crate::reporter::event::{
+        ListDep, MsrvResult, Progress, SetOutputMessage, ShowOutputMessage, VerifyOutput,
+    };
+    use crate::reporter::handler::minimal_output_handler::MinimalOutputHandler;
+    use crate::reporter::{Message, ReporterSetup, TestReporter};
+    use crate::toolchain::OwnedToolchainSpec;
+    use crate::{semver, Action, Config, Event};
+    use cargo_metadata::PackageId;
+    use serde::Deserialize;
+    use std::convert::TryInto;
+    use std::path::Path;
+    use std::sync::Arc;
+    use storyteller::{EventHandler, EventListener, FinishProcessing, Reporter};
+
+    #[test]
+    fn find_with_result() {
+        let config = Config::new(Action::Find, "my-target");
+        let min_available = BareVersion::ThreeComponents(1, 0, 0);
+        let max_available = BareVersion::ThreeComponents(2, 0, 0);
+
+        let event = MsrvResult::new_msrv(
+            semver::Version::new(1, 10, 100),
+            &config,
+            min_available,
+            max_available,
+        );
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "1.10.100\n");
+    }
+
+    #[test]
+    fn find_without_result() {
+        let config = Config::new(Action::Find, "my-target");
+        let min_available = BareVersion::ThreeComponents(1, 0, 0);
+        let max_available = BareVersion::ThreeComponents(2, 0, 0);
+
+        let event = MsrvResult::none(&config, min_available, max_available);
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "none\n");
+    }
+
+    #[test]
+    fn list_direct_deps() {
+        let config = Config::new(Action::Find, "my-target");
+        let min_available = BareVersion::ThreeComponents(1, 0, 0);
+        let max_available = BareVersion::ThreeComponents(2, 0, 0);
+
+        let package_id = PackageId {
+            repr: "hello_world".to_string(),
+        };
+        let dep_graph = DependencyGraph::empty(package_id);
+        let event = ListDep::new(ListMsrvVariant::DirectDeps, dep_graph);
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "unsupported\n");
+    }
+
+    #[test]
+    fn set_output() {
+        let event = SetOutputMessage::new(
+            BareVersion::TwoComponents(1, 20),
+            Path::new("/my/path").to_path_buf(),
+        );
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "1.20\n");
+    }
+
+    #[test]
+    fn show_output() {
+        let event = ShowOutputMessage::new(
+            BareVersion::ThreeComponents(1, 40, 3),
+            Path::new("/my/path").to_path_buf(),
+        );
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "1.40.3\n");
+    }
+
+    #[test]
+    fn verify_true() {
+        let event = VerifyOutput::compatible(OwnedToolchainSpec::new(
+            &semver::Version::new(1, 2, 3),
+            "test_target",
+        ));
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "true\n");
+    }
+
+    #[test]
+    fn verify_false_no_error_message() {
+        let event = VerifyOutput::incompatible(
+            OwnedToolchainSpec::new(&semver::Version::new(1, 2, 3), "test_target"),
+            None,
+        );
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "false\n");
+    }
+
+    #[test]
+    fn verify_false_with_error_message() {
+        let event = VerifyOutput::incompatible(
+            OwnedToolchainSpec::new(&semver::Version::new(1, 2, 3), "test_target"),
+            Some("error message".to_string()),
+        );
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert_eq!(content.as_ref(), "false\n");
+    }
+
+    #[test]
+    fn unreported_event() {
+        let event = Progress::new(1, 100, 50);
+
+        let buffer = Vec::new();
+        let handler = MinimalOutputHandler::new(buffer);
+        handler.handle(event.into());
+
+        let output = handler.inner().clone();
+        let content = String::from_utf8_lossy(&output);
+        assert!(content.as_ref().is_empty());
+    }
+}

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -35,6 +35,12 @@ impl<'spec> ToolchainSpec<'spec> {
     }
 }
 
+impl<'r> From<ToolchainSpec<'r>> for OwnedToolchainSpec {
+    fn from(spec: ToolchainSpec<'r>) -> Self {
+        spec.to_owned()
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct OwnedToolchainSpec {


### PR DESCRIPTION
This output format only reports the final result of a subcommand.
If the subcommand fails with an unexpected error, no output may be given,
but a failure exit code can still be expected.

- [x] Changelog
- [x] Book
- [x] Add VerifyOutput to verify
- ~~Consider printing oneline errors~~ Monitoring: if this is desired: please open an issue

closes #370 