### PR TITLE
Ignore ansi-term advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,4 +32,4 @@ license-files = [
 vulnerability = "deny"
 unmaintained = "deny"
 notice = "deny"
-ignore = []
+ignore = ["RUSTSEC-2021-0139"]


### PR DESCRIPTION
Ignore the ansi-term is unmaintained advisory for now, since it blocks our PR queue, and has no known vulnerabilities.
When tracing-subscriber releases a patch which replaces this dependency, we should remove it from the ignore list again.
.