### PR TITLE
Rename ambiguous is_error field of TerminateWithFailure

### DIFF
--- a/src/reporter/handler/human_progress_handler.rs
+++ b/src/reporter/handler/human_progress_handler.rs
@@ -96,10 +96,10 @@ impl EventHandler for HumanProgressHandler {
                 }
             }
             Message::SubcommandResult(result) => self.handle_subcommand_result(result),
-            Message::TerminateWithFailure(termination) if termination.is_error() => {
+            Message::TerminateWithFailure(termination) if termination.should_highlight() => {
                 self.pb.println(format!("\n\n{}", termination.as_message().red()));
             }
-            Message::TerminateWithFailure(termination) if !termination.is_error() => {
+            Message::TerminateWithFailure(termination) if !termination.should_highlight() => {
                 self.pb.println(format!("\n\n{}", termination.as_message().dimmed().bold()));
             }
             _ => {}


### PR DESCRIPTION
Is now called highlight to show it just changes the way the message is formatted (it's markup). 

Since this is not relevant to the JSON output type, a serde skip attribute was added to the highlight field.

Although this is a small improvement, it's still not a perfect name. Perhaps we should instead simply wrap the error into this type, and then let the formatter deal with markup.