### PR TITLE
Remove left-over print to stderr

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -1,4 +1,5 @@
 use crate::command::RustupCommand;
+use crate::error::RustupInstallFailed;
 use crate::reporter::event::SetupToolchain;
 use crate::toolchain::ToolchainSpec;
 use crate::{CargoMSRVError, EventReporter, TResult};
@@ -41,16 +42,8 @@ impl<'reporter, R: EventReporter> DownloadToolchain for ToolchainDownloader<'rep
                         "rustup failed to install toolchain"
                     );
 
-                    eprintln!(
-                        "Toolchain Download Failed -> \n\n{:?}\n{:?}\n{:?}\n{:?}\n<-\n\n",
-                        toolchain.spec(),
-                        rustup.stdout(),
-                        rustup.stderr(),
-                        "rustup failed to install toolchain"
-                    );
-
                     return Err(CargoMSRVError::RustupInstallFailed(
-                        toolchain.spec().to_string(),
+                        RustupInstallFailed::new(toolchain.spec(), rustup.stderr()),
                     ));
                 }
 


### PR DESCRIPTION
Printing is handled by the handlers through the storyteller library; this enables us to print in the correct output format appropriately (e.g. human, json, etc.)

closes #486 