### PR TITLE
Allow building in environments where vergen doesn't work

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,5 +4,7 @@ fn main() {
     // generate build info
     let mut config = Config::default();
     *config.git_mut().sha_kind_mut() = ShaKind::Short;
-    vergen(config).expect("Unable to generate build info with 'vergen'");
+    if let Err(e) = vergen(config) {
+        eprintln!("Unable to set build metadata: '{}'", e);
+    }
 }


### PR DESCRIPTION
E.g. when there is no git repository.