### PR TITLE
Do not build the rust-dist rust-releases source by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 
 
 [features]
-default = ["rust-releases-dist-source"]
+default = []
 rust-releases-dist-source = ["rust-releases/rust-releases-rust-dist"]
 
 


### PR DESCRIPTION
This source includes the rather large aws sdk  dependency tree.