### PR TITLE
Fix Arch Linux repo link in book

### DIFF
--- a/book/src/getting-started/installation.md
+++ b/book/src/getting-started/installation.md
@@ -31,7 +31,7 @@ cargo install cargo-msrv --git https://github.com/foresterre/cargo-msrv.git --br
 
 ### Arch Linux 🔸
 
-cargo-msrv is available from the Arch Linux [community repository](https://archlinux.org/packages/community/x86_64/cargo-msrv/).
+cargo-msrv is available from the Arch Linux [extra repository](https://archlinux.org/packages/extra/x86_64/cargo-msrv/).
 
 **How to install?**
 


### PR DESCRIPTION
Same as #689, but instead for the book instead of the readme.