### PR TITLE
Lock indicatif to 0.17.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,14 +1085,13 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.4"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db45317f37ef454e6519b6c3ed7d377e5f23346f0823f86e65ca36912d1d0ef8"
+checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
 dependencies = [
  "console",
- "instant",
  "number_prefix",
- "portable-atomic",
+ "portable-atomic 0.3.20",
  "unicode-width",
 ]
 
@@ -1423,6 +1422,15 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "portable-atomic"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e30165d31df606f5726b090ec7592c308a0eaf61721ff64c9a3018e344a8753e"
+dependencies = [
+ "portable-atomic 1.3.3",
+]
 
 [[package]]
 name = "portable-atomic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ camino = "1.1" # utf-8 paths
 cargo_metadata = "0.15.4" # resolving Cargo manifest metadata (consider `guppy`!)
 clap = { version = "4.3.0", features = ["derive"] } # parse CLI arguments
 dirs = "5.0.1" # common directories
-indicatif = "0.17.4" # UI
+indicatif = "=0.17.3" # UI
 once_cell = "1.17.2" # lazy data structures and thunking
 owo-colors = "3.5.0" # color support for the terminal
 petgraph = "0.6.3" # graph data structures


### PR DESCRIPTION
The 0.17.4 release causes rendering issues for our spinner, and status message, and any status message after the first.

workaround for #706 