### PR TITLE
Replace `cargo check --all` in docs

### DIFF
--- a/book/src/commands/find.md
+++ b/book/src/commands/find.md
@@ -13,7 +13,7 @@ This command will test your project by running various Rust toolchains against y
 toolchains will be tested, and the amount of tests ran, depends on the search strategy, the amount of toolchains
 available and of course the limiting factor of the project which will determine the MSRV. We usually call each test a
 cargo-msrv _check_. By default, the check command, the command used to test whether toolchain passes or fails a check,
-is `cargo check --all`.
+is `cargo check`.
 
 There are currently two search strategies: _linear_ (default) and _bisect_. Linear tests projects against toolchains in a
 most-recent to least-recent order. When a check fails, the previous Rust (if any) version is returned as the MSRV (i.e. the highest still
@@ -153,7 +153,7 @@ Prints cargo-msrv version information
 **`--` ...cmd** 
 
 When provided, the trailing command (`cmd`) will be used as the _cargo-msrv check_ command, instead of the default
-`cargo check --all`. This `cmd` must be runnable by `rustup` through `rustup run <toolchain> <cmd>`.
+`cargo check`. This `cmd` must be runnable by `rustup` through `rustup run <toolchain> <cmd>`.
 
 
 ## EXAMPLES

--- a/book/src/commands/verify.md
+++ b/book/src/commands/verify.md
@@ -44,7 +44,7 @@ fn main() {
 }
 ```
 
-We check whether the MSRV's  check command, in this case the default `cargo check --all`, can be satisfied.
+We check whether the MSRV's  check command, in this case the default `cargo check`, can be satisfied.
 The crate author specified the MSRV in the Cargo.toml, using the `package.rust-version` key. 
 Since the example crate used no features requiring a more recent version than Rust 1.56, the check will be satisfied,
 and the program returns a with exit code 0 (success).
@@ -74,7 +74,7 @@ fn main() {
 }
 ```
 
-We check whether the MSRV's  check command, in this case the default `cargo check --all`, can be satisfied.
+We check whether the MSRV's  check command, in this case the default `cargo check`, can be satisfied.
 The crate author specified the MSRV in the Cargo.toml, using the `package.rust-version` key.
 Since the example crate used a feature requiring a more recent version than Rust 1.56, the check cannot be satisfied,
 and the program returns a with a non-zero exit code (failure).

--- a/book/src/migration-guide/v0.15_v0.16_json.md
+++ b/book/src/migration-guide/v0.15_v0.16_json.md
@@ -40,7 +40,7 @@ The v0.15 `mode` message consisted of:
    // The toolchain that will be used
   "toolchain":"x86_64-unknown-linux-gnu",
   // Command used to check a version. The key will be absent for mode 'list'
-  "check_cmd":"cargo check --all"
+  "check_cmd":"cargo check"
 }
 ```
 Examples of messages which replace the information reported by the v0.15 `mode` message:
@@ -75,7 +75,7 @@ Previously, you would receive the following event:
   // The toolchain that is being used
   "toolchain": "x86_64-unknown-linux-gnu",
   // The command used to check each version. The key will be absent for mode 'list'
-  "check_cmd": "cargo check --all"
+  "check_cmd": "cargo check"
 }
 ```
 
@@ -116,7 +116,7 @@ Previously, you would receive the following event:
   // The toolchain that is being used
   "toolchain": "x86_64-unknown-linux-gnu",
   // The command used to check each version
-  "check_cmd": "cargo check --all"
+  "check_cmd": "cargo check"
 }
 ```
 
@@ -161,7 +161,7 @@ The v0.15 output had the following format:
   // The toolchain that is being used
   "toolchain": "x86_64-unknown-linux-gnu",
   // The command used to check each version. The key will be absent for mode 'list'
-  "check_cmd": "cargo check --all"
+  "check_cmd": "cargo check"
 }
 ```
 


### PR DESCRIPTION
There are some lingering instances of `cargo check --all`, even after the closure of #384. This replaces those occurrences with the correct `cargo check`. (Fixes #384.)