### PR TITLE
infra: Remove nightly from ci-test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [ubuntu-stable, macos-stable, win-gnu-stable, win-msvc-stable, ubuntu-beta, ubuntu-nightly]
+        build: [ubuntu-stable, macos-stable, win-gnu-stable, win-msvc-stable, ubuntu-beta]
         include:
           - build: ubuntu-stable
             os: ubuntu-latest
@@ -39,9 +39,6 @@ jobs:
             os: ubuntu-latest
             rust: beta
 
-          - build: ubuntu-nightly
-            os: ubuntu-latest
-            rust: nightly
     steps:
       - name: checkout_repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Output of cargo msrv tests is currently different on nightly, compared to stable (and beta). As such, some of our end-to-end tests were failing. Nightly is only a nice to have for now, and handling the output separately is not in my best interest regarding time management. As such, I decided to remove it.