### PR TITLE
chore: Pin nightly release for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install_rust_nightly
-        uses: dtolnay/rust-toolchain@nightly-2024-02-01 # pinned because of https://github.com/tkaitchuck/aHash/issues/200#issuecomment-1936283358
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-02-01 # pinned because of https://github.com/tkaitchuck/aHash/issues/200#issuecomment-1936283358
 
       - name: install_code_coverage_tool
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install_rust_nightly
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@nightly-2024-02-01 # pinned because of https://github.com/tkaitchuck/aHash/issues/200#issuecomment-1936283358
 
       - name: install_code_coverage_tool
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/src/bin/cargo-msrv.rs
+++ b/src/bin/cargo-msrv.rs
@@ -251,7 +251,7 @@ impl TracingTarget {
 }
 
 enum TracingGuard {
-    NonBlockingGuard(tracing_appender::non_blocking::WorkerGuard),
+    NonBlockingGuard(#[allow(dead_code)] tracing_appender::non_blocking::WorkerGuard),
     None,
 }
 


### PR DESCRIPTION
New nighly feature broke crc32c and ahash.