### PR TITLE
Fix `--manifest-path Cargo.toml`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -272,6 +272,9 @@ impl RustupInstallFailed {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PathError {
+    #[error("'{}' does not exist", .0.display())]
+    DoesNotExist(PathBuf),
+
     #[error("No parent directory for '{}'", .0.display())]
     NoParent(PathBuf),
 


### PR DESCRIPTION
Fixes #928.

### Observation

- `--manifest-path ./Cargo.toml` works
- `--manifest-path Cargo.toml` does not:
  ```
  Unable to run the check command: 'cargo check --all-features --target thumbv7em-none-eabihf' at ''
  ```

### Cause
- `path.parent()` yields an empty string for `Cargo.toml`

### Proposed solution
- `path.canonicalize().parent()`.

### Why this is a problem
- `--manifest-path Cargo.toml` is an accepted flag for normal `cargo`. In my case it caused an error in combination with `minimal-versions`, which adds `--manifest-path Cargo.toml` to the command:
  ```
  cargo minimal-versions msrv verify
  ```
  which fails without this PR, and succeeds with it.