### PR TITLE
refactor: Rename CheckCommandOpts to CustomCheckOpts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::cli::custom_check_opts::CheckCommandOpts;
+use crate::cli::custom_check_opts::CustomCheckOpts;
 use crate::cli::find_opts::FindOpts;
 use crate::cli::rust_releases_opts::RustReleasesOpts;
 use crate::cli::shared_opts::SharedOpts;
@@ -150,7 +150,7 @@ pub struct VerifyOpts {
     pub toolchain_opts: ToolchainOpts,
 
     #[command(flatten)]
-    pub cargo_check_opts: CheckCommandOpts,
+    pub custom_check_opts: CustomCheckOpts,
 
     /// The Rust version, to check against for toolchain compatibility
     ///

--- a/src/cli/custom_check_opts.rs
+++ b/src/cli/custom_check_opts.rs
@@ -2,7 +2,7 @@ use clap::Args;
 
 #[derive(Debug, Args)]
 #[command(next_help_heading = "Custom check options")]
-pub struct CheckCommandOpts {
+pub struct CustomCheckOpts {
     /// Forwards the provided features to cargo, when running cargo-msrv with the default compatibility
     /// check command.
     ///
@@ -26,5 +26,5 @@ pub struct CheckCommandOpts {
 
     /// Supply a custom `check` command to be used by cargo msrv
     #[arg(last = true)]
-    pub custom_check_command: Option<Vec<String>>,
+    pub custom_check_opts: Option<Vec<String>>,
 }

--- a/src/cli/find_opts.rs
+++ b/src/cli/find_opts.rs
@@ -1,4 +1,4 @@
-use crate::cli::custom_check_opts::CheckCommandOpts;
+use crate::cli::custom_check_opts::CustomCheckOpts;
 use crate::cli::rust_releases_opts::RustReleasesOpts;
 use crate::cli::toolchain_opts::ToolchainOpts;
 use clap::Args;
@@ -59,5 +59,5 @@ pub struct FindOpts {
     pub toolchain_opts: ToolchainOpts,
 
     #[command(flatten)]
-    pub custom_check_opts: CheckCommandOpts,
+    pub custom_check_opts: CustomCheckOpts,
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -25,7 +25,7 @@ pub mod set;
 pub mod show;
 pub mod verify;
 
-use crate::cli::custom_check_opts::CheckCommandOpts;
+use crate::cli::custom_check_opts::CustomCheckOpts;
 use crate::cli::rust_releases_opts::Edition;
 use crate::cli::{CargoMsrvOpts, SubCommand};
 use crate::default_target::default_target;
@@ -232,13 +232,13 @@ pub struct CheckCommandContext {
     pub rustup_command: Option<Vec<String>>,
 }
 
-impl From<CheckCommandOpts> for CheckCommandContext {
-    fn from(opts: CheckCommandOpts) -> Self {
+impl From<CustomCheckOpts> for CheckCommandContext {
+    fn from(opts: CustomCheckOpts) -> Self {
         Self {
             cargo_features: opts.features,
             cargo_all_features: opts.all_features,
             cargo_no_default_features: opts.no_default_features,
-            rustup_command: opts.custom_check_command,
+            rustup_command: opts.custom_check_opts,
         }
     }
 }


### PR DESCRIPTION
Use a consistent name shared between the top level "find" command and the subcommand level, used by the verify subcommand.