### PR TITLE
The CLI arguments `--target` and `--add-component` were previously inadvertently ignored when provided to `cargo msrv verify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 * The rust-toolchain file will now be overwritten if a rust-toolchain file was already present.
 * Updated user output formatting to be more consistent between output formats.
 * `cargo-msrv` now requires paths to be UTF-8.
-* `--write-msrv` now writes two, instead of three component version numbers
+* `--write-msrv` now writes two, instead of three component version numbers.
 
 #### Infra
 
@@ -51,10 +51,12 @@ the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 * Subcommand `cargo msrv set` will now return an error when the Cargo manifest solely consists of a virtual workspace.
 * The program will no longer return an unformatted message when a command failed and the output format was set to json.
 * Fix issue where reading the fallback MSRV from a TOML inline table was not possible.
-* Fix an index out-of-bounds panic which occurred if the filtered Rust releases search space was empty
-* Use compilation target instead of build machine target for MSRV checks
-* Fix issue where `--manifest-path Cargo.toml` would yield an empty manifest path
+* Fix an index out-of-bounds panic which occurred if the filtered Rust releases search space was empty.
+* Use compilation target instead of build machine target for MSRV checks.
+* Fix issue where `--manifest-path Cargo.toml` would yield an empty manifest path.
 * Supply provided components to `verify` subcommand
+* The CLI arguments `--target` and `--add-component` were previously inadvertently ignored when provided
+  to `cargo msrv verify`.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ If you found an issue, have a suggestion or want to provide feedback or insights
 the [issue tracker](https://github.com/foresterre/cargo-msrv/issues), or open a topic in
 the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 
-## [Unreleased]
+## Unreleased
 
 ### Added
 
@@ -62,7 +62,21 @@ the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 * Removed option to disable filtering the Rust releases search space by the Rust edition in from the Cargo
   manifest, `--no-read-min-edition`.
 
-[Unreleased]: https://github.com/foresterre/cargo-msrv/compare/v0.15.1...HEAD
+### Known issues
+
+* The CLI
+  arguments `--features`, `--all-features`, `--no-default-features`, `--min`, `--max`, `--include-all-patch-releases`
+  and `--release-source` are ignored when provided to the `verify` subcommand. Workaround: supply these arguments
+  directly to the top-level command, e.g. `cargo msrv --all-features verify`.
+* The CLI arguments `--target` and `--add-component` can be provided to both the top-level `cargo msrv` command, and
+  the `cargo msrv verify` subcommand, however if they're provided to both, then only the arguments of the subcommand are
+  considered.
+  Example: `cargo msrv --target x --add-component a --add-component b verify --target y --add-component c --add-component d`
+  does not reject or collect the `--target x --add-component a --add-component b` portion; the program will only be
+  aware of the `--target y --add-component c --add-component d` arguments.
+* The CLI arguments `--target` and `--add-component` are shown to be available globally (i.e. both at the top
+  level `cargo msrv` command and at the subcommand level, e.g. `cargo msrv verify`), even for subcommands which do not
+  consume these arguments like `cargo msrv list`.
 
 ## [0.15.1] - 2022-02-24
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,6 @@ use crate::cli::custom_check_opts::CustomCheckOpts;
 use crate::cli::find_opts::FindOpts;
 use crate::cli::rust_releases_opts::RustReleasesOpts;
 use crate::cli::shared_opts::SharedOpts;
-use crate::cli::toolchain_opts::ToolchainOpts;
 use crate::context::list::ListMsrvVariant;
 use crate::manifest::bare_version::BareVersion;
 use clap::{Args, Parser, Subcommand};
@@ -145,9 +144,6 @@ pub struct SetOpts {
 pub struct VerifyOpts {
     #[command(flatten)]
     pub rust_releases_opts: RustReleasesOpts,
-
-    #[command(flatten)]
-    pub toolchain_opts: ToolchainOpts,
 
     #[command(flatten)]
     pub custom_check_opts: CustomCheckOpts,

--- a/src/cli/toolchain_opts.rs
+++ b/src/cli/toolchain_opts.rs
@@ -6,12 +6,13 @@ use clap::Args;
 #[command(next_help_heading = "Toolchain options")]
 pub struct ToolchainOpts {
     /// Check against a custom target (instead of the rustup default)
-    #[arg(long, value_name = "TARGET")]
+    // Unfortunately, Clap will not reject the
+    #[arg(long, value_name = "TARGET", global = true)]
     pub target: Option<String>,
 
     /// Components be added to the toolchain
     ///
     /// Can be supplied multiple times to add multiple components.
-    #[arg(long, value_name = "COMPONENT")]
+    #[arg(long, value_name = "COMPONENT", global = true)]
     pub add_component: Vec<String>,
 }


### PR DESCRIPTION
closes #936

Fixes the issue where the CLI arguments `--target` and `--add-component` were previously inadvertently ignored when provided to `cargo msrv verify` by setting their derived `clap::Arg's` to `global = true` like we do for the shared opts. This has some side-effects:

- The arguments are now available to all subcommands, even those which do not consume them. This was already partially true, when the arguments were provided to the top level. For example, `cargo msrv --target x list` was valid (on the CLI parsing level) before, even though the `list` subcommand does not consume them. Now `cargo msrv list --target x` also works, but also doesn't do anything. This may be especially confusing for things were it could have made sense, like `cargo msrv set <value> --target x`; i.e. set the MSRV but only for target `x`. 
- Despite that the number of arguments being accepted is `1` (even if you explicitly set num_args), by virtue of the derived `Option<T>`, you can still set these arguments at both the top level and the the subcommand level (e.g. `cargo msrv --target x verify --target y` is accepted, while `cargo msrv --target x --target y verify` or `cargo msrv verify --target x --target y` are not).

I've documented these in the known issues section in the CHANGELOG.

Despite these downsides, this feels like the pragmatic choice.

Alternative's I tried were to separate their definitions, i.e. add a `ToolchainOptsFind` and a `ToolchainOptsVerify`, use `conflicts_with` relations, using [`ArgGroups`](https://docs.rs/clap/latest/clap/struct.ArgGroup.html) (1) and quite a few others, but none seemed to do what I wanted:

* Accept `--target` and `--add-components` on just the `cargo msrv` and `cargo msrv verify` levels
* For each of these argument types, e.g. `--target`, if it were provided to the subcommand, then it should be rejected if it were also provided to the top level, and vice versa.

(1) The docs mention quote "Finally, you may use ArgGroups to pull a value from a group of arguments when you don’t care exactly which argument was actually used at runtime." which to me suggests that it should be possible to create different named things, for which the value is shared. But how to actually do this with the derive macro, where you can't just `get_{}` from `ArgMatches`, I'm not sure.