### PR TITLE
Make `--output-format` and `--no-user-output` mutually exclusive

### DIFF
--- a/src/cli/shared_opts.rs
+++ b/src/cli/shared_opts.rs
@@ -36,7 +36,7 @@ pub struct UserOutputOpts {
     output_format: OutputFormat,
 
     /// Disable user output
-    #[arg(long, global = true)]
+    #[arg(long, global = true, conflicts_with = "output_format")]
     no_user_output: bool,
 }
 


### PR DESCRIPTION
See https://github.com/foresterre/cargo-msrv/discussions/970#discussioncomment-10274960

When used together, execution now fails, as desired:
```
error: the argument '--output-format <FORMAT>' cannot be used with '--no-user-output'

Usage: cargo msrv verify --output-format <FORMAT> [-- <CUSTOM_CHECK_OPTS>...]
```
