### PR TITLE
Revert "build(deps): bump owo-colors from 4.0.0 to 5.0.0"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,9 +1524,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "5.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fd1e2f6b8c2caa4ede09a3c1b8fcab7b8b3c0c82987e685eb0df047b044f5"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "p256"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap = { version = "4.5.17", features = ["derive"] } # parse CLI arguments
 dirs = "5.0.1" # common directories
 indicatif = "0.17.8" # UI
 once_cell = "1.19.0" # lazy data structures and thunking
-owo-colors = "5.0.0" # color support for the terminal
+owo-colors = "4.0.0" # color support for the terminal
 petgraph = "0.6.5" # graph data structures
 rust-releases = { version = "0.28.0", default-features = false, features = ["rust-changelog"] } # get the available rust versions
 serde = { version = "1.0", features = ["derive"] } # serialization and deserialization


### PR DESCRIPTION
This reverts commit 1b30c8fb9645bc3d8462b6c35a1e899a526ed277.