### PR TITLE
Add metadata for Binstall so that it can download binaries immediately (without brute forcing to find the correct URL)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ rust-version = "1.78"
 [package.metadata.release]
 tag-name = "v{{version}}"
 
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }{ archive-suffix }"
+
 [dependencies]
 bisector = "0.4.0" # bisection with a custom comparator
 camino = "1.1" # utf-8 paths


### PR DESCRIPTION
I learned this from [Binstall's documentation](https://github.com/cargo-bins/cargo-binstall/blob/92a022bad41abdae4221a6e901e455359cee03fe/SUPPORT.md#support-for-cargo-binstall), and it fixed a similar issue with my crate.

is expected to close #1033 
