### PR TITLE
Add e2e test via Github workflow

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - mainLOCAL_URL
+      - main
   merge_group:
   schedule:
     - cron: '00 06 * * *'
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [ubuntu, macos, windows]
+        build: [ ubuntu, macos, windows ]
         include:
           - build: ubuntu
             os: ubuntu-latest

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -69,6 +69,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: debug_manual_install
         run: rustup install --profile minimal 1.78.0
+      - name: debug_manual_install_two
+        run: rustup install --profile minimal 1.78.0
+
 
   # The same as the 'msrv' job, except it takes the latest release, including beta releases
   # We don't use --all-features here!

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -22,7 +22,7 @@ jobs:
             os: ubuntu-latest
 
           - build: macos
-            os: macos-13
+            os: macos-latest
 
           - build: windows
             os: windows-latest

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -32,6 +32,9 @@ jobs:
         uses: actions/checkout@v4
       - name: install_rust
         uses: dtolnay/rust-toolchain@stable
+      - name: workaround_overwrite_cargo_home_for_windows # normally set by dtolnay/rust-toolchain@stable, but always with a forward slash path separator
+        if: matrix.build == 'windows'
+        run: echo CARGO_HOME=${CARGO_HOME:-$USERPROFILE\\.cargo} >> $GITHUB_ENV
       - name: install_cargo_msrv
         if: matrix.build == 'ubuntu'
         run: cargo install cargo-msrv

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -4,14 +4,28 @@ on:
   push:
     branches:
       - master
-      - main
+      - mainLOCAL_URL
   merge_group:
   schedule:
     - cron: '00 06 * * *'
 jobs:
+  # MSRV check and e2e test
   msrv:
     name: msrv
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [ubuntu, macos, windows]
+        include:
+          - build: ubuntu
+            os: ubuntu-latest
+
+          - build: macos
+            os: macos-13
+
+          - build: windows
+            os: windows-latest
     continue-on-error: true
     steps:
       - name: checkout_repo
@@ -19,7 +33,11 @@ jobs:
       - name: install_rust
         uses: dtolnay/rust-toolchain@stable
       - name: install_cargo_msrv
-        run: cargo install cargo-msrv --all-features
+        if: matrix.build == 'ubuntu'
+        run: cargo install cargo-msrv
+      - name: install_cargo_msrv_no_default
+        if: matrix.build != 'ubuntu'
+        run: cargo install cargo-msrv --no-default-features
       - name: version_of_cargo_msrv
         run: cargo msrv --version
       - name: run_cargo_msrv

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -54,6 +54,21 @@ jobs:
         if: ${{ failure() }}
         run: cargo msrv verify --log-target stdout --log-level debug --no-user-output
         shell: bash
+      - name: debug_manual_install
+        if: ${{ failure() }}
+        run: rustup install --profile minimal 1.78.0
+        shell: bash
+
+  msrv_windows_debug:
+    runs-on: windows-latest
+    continue-on-error: true
+    steps:
+      - name: checkout_repo
+        uses: actions/checkout@v4
+      - name: install_rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: debug_manual_install
+        run: rustup install --profile minimal 1.78.0
 
   # The same as the 'msrv' job, except it takes the latest release, including beta releases
   # We don't use --all-features here!

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -32,9 +32,6 @@ jobs:
         uses: actions/checkout@v4
       - name: install_rust
         uses: dtolnay/rust-toolchain@stable
-      - name: workaround_overwrite_cargo_home_for_windows # normally set by dtolnay/rust-toolchain@stable, but always with a forward slash path separator
-        if: matrix.build == 'windows'
-        run: echo CARGO_HOME=${CARGO_HOME:-$USERPROFILE\\.cargo} >> $GITHUB_ENV
       - name: install_cargo_msrv
         if: matrix.build == 'ubuntu'
         run: cargo install cargo-msrv

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -44,7 +44,12 @@ jobs:
         run: cargo msrv --output-format json verify
       - name: run_cargo_msrv_on_verify_failure
         if: ${{ failure() }}
-        run: cargo msrv find --output-format json
+        run: cargo msrv verify --log-target stdout --log-level debug --no-user-output
+      - name: debug_run_cargo_msrv
+        run: cargo msrv --output-format json verify
+      - name: debug_run_cargo_msrv_on_verify_failure
+        if: ${{ failure() }}
+        run: cargo msrv find --log-target stdout --log-level debug --no-user-output
 
   # The same as the 'msrv' job, except it takes the latest release, including beta releases
   # We don't use --all-features here!
@@ -61,7 +66,7 @@ jobs:
         with:
           tool: cargo-binstall
       - name: install_cargo_msrv_bin
-        run: cargo binstall --version 0.16.0 --no-confirm cargo-msrv
+        run: cargo binstall --version 0.16.2 --no-confirm cargo-msrv
       - name: version_of_cargo_msrv
         run: cargo msrv --version
       - name: run_cargo_msrv

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -44,12 +44,10 @@ jobs:
         run: cargo msrv --output-format json verify
       - name: run_cargo_msrv_on_verify_failure
         if: ${{ failure() }}
-        run: cargo msrv verify --log-target stdout --log-level debug --no-user-output
-      - name: debug_run_cargo_msrv
         run: cargo msrv --output-format json verify
-      - name: debug_run_cargo_msrv_on_verify_failure
+      - name: debug_run_cargo_msrv_verify
         if: ${{ failure() }}
-        run: cargo msrv find --log-target stdout --log-level debug --no-user-output
+        run: cargo msrv verify --log-target stdout --log-level debug --no-user-output
 
   # The same as the 'msrv' job, except it takes the latest release, including beta releases
   # We don't use --all-features here!

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -35,19 +35,25 @@ jobs:
       - name: install_cargo_msrv
         if: matrix.build == 'ubuntu'
         run: cargo install cargo-msrv
+        shell: bash
       - name: install_cargo_msrv_no_default
         if: matrix.build != 'ubuntu'
         run: cargo install cargo-msrv --no-default-features
+        shell: bash
       - name: version_of_cargo_msrv
         run: cargo msrv --version
+        shell: bash
       - name: run_cargo_msrv
         run: cargo msrv --output-format json verify
+        shell: bash
       - name: run_cargo_msrv_on_verify_failure
         if: ${{ failure() }}
         run: cargo msrv --output-format json verify
+        shell: bash
       - name: debug_run_cargo_msrv_verify
         if: ${{ failure() }}
         run: cargo msrv verify --log-target stdout --log-level debug --no-user-output
+        shell: bash
 
   # The same as the 'msrv' job, except it takes the latest release, including beta releases
   # We don't use --all-features here!

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -68,9 +68,9 @@ jobs:
       - name: install_rust
         uses: dtolnay/rust-toolchain@stable
       - name: debug_manual_install
-        run: rustup install --profile minimal 1.78.0
+        run: rustup install --no-self-update --profile minimal 1.78.0
       - name: debug_manual_install_two
-        run: rustup install --profile minimal 1.78.0
+        run: rustup install --no-self-update --profile minimal 1.78.0
 
 
   # The same as the 'msrv' job, except it takes the latest release, including beta releases

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [ ubuntu, macos, windows ]
+        build: [ ubuntu, macos ] # [, windows] ... Disabled Windows for now, see #1036
         include:
           - build: ubuntu
             os: ubuntu-latest
@@ -24,8 +24,8 @@ jobs:
           - build: macos
             os: macos-latest
 
-          - build: windows
-            os: windows-latest
+    #          - build: windows
+    #            os: windows-latest
     continue-on-error: true
     steps:
       - name: checkout_repo
@@ -35,46 +35,18 @@ jobs:
       - name: install_cargo_msrv
         if: matrix.build == 'ubuntu'
         run: cargo install cargo-msrv
-        shell: bash
       - name: install_cargo_msrv_no_default
         if: matrix.build != 'ubuntu'
         run: cargo install cargo-msrv --no-default-features
-        shell: bash
       - name: version_of_cargo_msrv
         run: cargo msrv --version
-        shell: bash
       - name: run_cargo_msrv
-        run: cargo msrv --output-format json verify
-        shell: bash
+        run: cargo msrv verify --output-format json
       - name: run_cargo_msrv_on_verify_failure
         if: ${{ failure() }}
-        run: cargo msrv --output-format json verify
-        shell: bash
-      - name: debug_run_cargo_msrv_verify
-        if: ${{ failure() }}
-        run: cargo msrv verify --log-target stdout --log-level debug --no-user-output
-        shell: bash
-      - name: debug_manual_install
-        if: ${{ failure() }}
-        run: rustup install --profile minimal 1.78.0
-        shell: bash
-
-  msrv_windows_debug:
-    runs-on: windows-latest
-    continue-on-error: true
-    steps:
-      - name: checkout_repo
-        uses: actions/checkout@v4
-      - name: install_rust
-        uses: dtolnay/rust-toolchain@stable
-      - name: debug_manual_install
-        run: rustup install --no-self-update --profile minimal 1.78.0
-      - name: debug_manual_install_two
-        run: rustup install --no-self-update --profile minimal 1.78.0
-
+        run: cargo msrv find --output-format json
 
   # The same as the 'msrv' job, except it takes the latest release, including beta releases
-  # We don't use --all-features here!
   msrv_pre_release:
     name: msrv_pre_release
     runs-on: ubuntu-latest
@@ -92,7 +64,7 @@ jobs:
       - name: version_of_cargo_msrv
         run: cargo msrv --version
       - name: run_cargo_msrv
-        run: cargo msrv --output-format json verify
+        run: cargo msrv verify --output-format json
       - name: run_cargo_msrv_on_verify_failure
         if: ${{ failure() }}
         run: cargo msrv find --output-format json
@@ -113,7 +85,7 @@ jobs:
       - name: version_of_cargo_msrv
         run: cargo msrv --version
       - name: run_cargo_msrv
-        run: cargo msrv --output-format json verify
+        run: cargo msrv verify --output-format json
       - name: run_cargo_msrv_on_verify_failure
         if: ${{ failure() }}
         run: cargo msrv find --output-format json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 
 * Toolchains installed with `rustup install` now use the `--no-self-update` flag
 
+### Known issues
+
+* Installing toolchains on GitHub Actions can fail for the windows runner (#1036)
+
 ## [0.16.2] - 2024-10-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 
 * Added `--workspace`, `--all`, `--package` and `--exclude` CLI options for package selection when in a Cargo project (
   with limited workspace support for now)
+* `cargo msrv find --write-msrv` is now aliased by `cargo msrv find --set`, which is consistent in terminology with
+  `cargo msrv set`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the [discussions section](https://github.com/foresterre/cargo-msrv/discussions).
 * Added `--workspace`, `--all`, `--package` and `--exclude` CLI options for package selection when in a Cargo project (
   with limited workspace support for now)
 
+### Changed
+
+* Toolchains installed with `rustup install` now use the `--no-self-update` flag
+
 ## [0.16.2] - 2024-10-10
 
 ### Fixed

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,7 @@
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0370" # proc-macro-error is unmaintained (via tabled > tabled_derive)
+    "RUSTSEC-2024-0370", # https://rustsec.org/advisories/RUSTSEC-2024-0370 `proc-macro-error` is unmaintained (via `tabled` > `tabled_derive`)
+    "RUSTSEC-2024-0384", # https://rustsec.org/advisories/RUSTSEC-2024-0384 `instant` is unmaintained (via `indicatif`)
 ]
 
 [licenses]

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -11,5 +11,13 @@ pub use rustup_toolchain_check::{RunCommand, RustupToolchainCheck};
 pub use testing::TestRunner;
 
 pub trait Check {
+    fn before(&self, _toolchain: &Toolchain) -> TResult<()> {
+        Ok(())
+    }
+
     fn check(&self, toolchain: &Toolchain) -> TResult<Outcome>;
+
+    fn after(&self, _toolchain: &Toolchain) -> TResult<()> {
+        Ok(())
+    }
 }

--- a/src/check/rustup_toolchain_check.rs
+++ b/src/check/rustup_toolchain_check.rs
@@ -225,7 +225,7 @@ pub struct RunCommand {
 }
 
 impl RunCommand {
-    pub fn default(cargo_command: CargoCommand) -> Self {
+    pub fn from_cargo_command(cargo_command: CargoCommand) -> Self {
         Self {
             command: cargo_command.into_args(),
         }

--- a/src/compatibility/mod.rs
+++ b/src/compatibility/mod.rs
@@ -10,6 +10,9 @@ pub use rustup_toolchain_check::{RunCommand, RustupToolchainCheck};
 #[cfg(test)]
 pub use testing::TestRunner;
 
+/// Implementers of this trait must determine whether a Rust toolchain is _supported_
+/// for a Rust project. This is a step in the process of determining the _minimally
+/// supported_ Rust version; the MSRV.
 pub trait IsCompatible {
     fn before(&self, _toolchain: &Toolchain) -> TResult<()> {
         Ok(())

--- a/src/compatibility/mod.rs
+++ b/src/compatibility/mod.rs
@@ -4,18 +4,18 @@ mod rustup_toolchain_check;
 #[cfg(test)]
 mod testing;
 
-use crate::{Outcome, TResult};
+use crate::{Compatibility, TResult};
 pub use rustup_toolchain_check::{RunCommand, RustupToolchainCheck};
 
 #[cfg(test)]
 pub use testing::TestRunner;
 
-pub trait Check {
+pub trait IsCompatible {
     fn before(&self, _toolchain: &Toolchain) -> TResult<()> {
         Ok(())
     }
 
-    fn check(&self, toolchain: &Toolchain) -> TResult<Outcome>;
+    fn is_compatible(&self, toolchain: &Toolchain) -> TResult<Compatibility>;
 
     fn after(&self, _toolchain: &Toolchain) -> TResult<()> {
         Ok(())

--- a/src/compatibility/testing.rs
+++ b/src/compatibility/testing.rs
@@ -1,5 +1,5 @@
-use crate::check::Check;
-use crate::outcome::Outcome;
+use crate::compatibility::IsCompatible;
+use crate::outcome::Compatibility;
 use crate::rust::Toolchain;
 use crate::semver::Version;
 use crate::TResult;
@@ -19,18 +19,18 @@ impl TestRunner {
     }
 }
 
-impl Check for TestRunner {
-    fn check(&self, toolchain: &Toolchain) -> TResult<Outcome> {
+impl IsCompatible for TestRunner {
+    fn is_compatible(&self, toolchain: &Toolchain) -> TResult<Compatibility> {
         let v = toolchain.version();
 
         if self.accept_versions.contains(toolchain.version()) {
-            Ok(Outcome::new_success(Toolchain::new(
+            Ok(Compatibility::new_success(Toolchain::new(
                 v.clone(),
                 self.target,
                 &[],
             )))
         } else {
-            Ok(Outcome::new_failure(
+            Ok(Compatibility::new_failure(
                 Toolchain::new(v.clone(), self.target, &[]),
                 "f".to_string(),
             ))

--- a/src/context/find.rs
+++ b/src/context/find.rs
@@ -1,4 +1,4 @@
-use crate::check::RunCommand;
+use crate::compatibility::RunCommand;
 use crate::cli::{CargoMsrvOpts, SubCommand};
 use crate::context::{
     CheckCommandContext, EnvironmentContext, RustReleasesContext, SearchMethod, ToolchainContext,

--- a/src/context/find.rs
+++ b/src/context/find.rs
@@ -83,7 +83,7 @@ impl FindContext {
                 .all_features(self.check_cmd.cargo_all_features)
                 .no_default_features(self.check_cmd.cargo_no_default_features);
 
-            RunCommand::default(cargo_command)
+            RunCommand::from_cargo_command(cargo_command)
         }
     }
 }

--- a/src/context/find.rs
+++ b/src/context/find.rs
@@ -1,5 +1,5 @@
-use crate::compatibility::RunCommand;
 use crate::cli::{CargoMsrvOpts, SubCommand};
+use crate::compatibility::RunCommand;
 use crate::context::{
     CheckCommandContext, EnvironmentContext, RustReleasesContext, SearchMethod, ToolchainContext,
 };

--- a/src/context/verify.rs
+++ b/src/context/verify.rs
@@ -3,7 +3,7 @@ use crate::context::{
     CheckCommandContext, EnvironmentContext, RustReleasesContext, ToolchainContext,
 };
 
-use crate::check::RunCommand;
+use crate::compatibility::RunCommand;
 use crate::error::CargoMSRVError;
 use crate::external_command::cargo_command::CargoCommand;
 use crate::sub_command::verify::RustVersion;

--- a/src/context/verify.rs
+++ b/src/context/verify.rs
@@ -78,7 +78,7 @@ impl VerifyContext {
                 .all_features(self.check_cmd.cargo_all_features)
                 .no_default_features(self.check_cmd.cargo_no_default_features);
 
-            RunCommand::default(cargo_command)
+            RunCommand::from_cargo_command(cargo_command)
         }
     }
 }

--- a/src/external_command/cargo_command.rs
+++ b/src/external_command/cargo_command.rs
@@ -33,7 +33,7 @@ impl CargoCommand {
 
     /// Intended to be used in conjunction with [`RunCommand`] and/or [`RustupCommand`].
     ///
-    /// [`RunCommand`]: crate::check::RunCommand
+    /// [`RunCommand`]: crate::compatibility::RunCommand
     /// [`RustupCommand`]: crate::external_command::rustup_command::RustupCommand
     // Currently we don't invoke it from here directly, but we might eventually, if
     // we want to also provide some nicer structs around parsing. However compared to

--- a/src/external_command/rustup_command.rs
+++ b/src/external_command/rustup_command.rs
@@ -73,7 +73,8 @@ impl RustupCommand {
     pub fn execute(mut self, cmd: &OsStr) -> TResult<RustupOutput> {
         debug!(
             cmd = ?cmd,
-            args = ?self.args.as_slice()
+            args = ?self.args.as_slice(),
+            current_dir = ?self.command.get_current_dir(),
         );
 
         self.command.arg(cmd);

--- a/src/external_command/rustup_command.rs
+++ b/src/external_command/rustup_command.rs
@@ -91,6 +91,7 @@ impl RustupCommand {
         let _span = self._span.enter();
 
         debug!(
+            name: "rustup_command_execute_start",
             cmd = ?cmd,
             args = ?self.args.as_slice(),
             current_dir = ?self.command.get_current_dir(),
@@ -111,6 +112,12 @@ impl RustupCommand {
             error,
             source: IoErrorSource::WaitForProcessAndCollectOutput(cmd.to_owned()),
         })?;
+
+        debug!(
+            name: "rustup_command_execute_finish",
+            cmd = ?cmd,
+            success = output.status.success(),
+        );
 
         Ok(RustupOutput {
             output,

--- a/src/external_command/rustup_command.rs
+++ b/src/external_command/rustup_command.rs
@@ -87,7 +87,7 @@ impl RustupCommand {
     /// * [RustupCommand::run](RustupCommand::run)
     /// * [RustupCommand::install](RustupCommand::install)
     /// * [RustupCommand::show](RustupCommand::show)
-    pub fn execute(mut self, cmd: &OsStr) -> TResult<RustupOutput> {
+    fn execute(mut self, cmd: &OsStr) -> TResult<RustupOutput> {
         let _span = self._span.enter();
 
         debug!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,10 +21,10 @@ extern crate core;
 extern crate tracing;
 
 pub use crate::context::{Context, OutputFormat, TracingOptions, TracingTargetOption};
-pub use crate::outcome::Outcome;
+pub use crate::outcome::Compatibility;
 pub use crate::sub_command::{Find, List, Set, Show, SubCommand, Verify};
 
-use crate::check::RustupToolchainCheck;
+use crate::compatibility::RustupToolchainCheck;
 use crate::context::ReleaseSource;
 use crate::error::{CargoMSRVError, TResult};
 use crate::reporter::event::{Meta, SelectedPackages, SubcommandInit};
@@ -32,8 +32,8 @@ use crate::reporter::{Event, Reporter};
 use rust::release_index;
 use rust_releases::semver;
 
-pub mod check;
 pub mod cli;
+pub mod compatibility;
 
 pub mod context;
 pub mod dependency_graph;

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -1,23 +1,23 @@
 //! The outcome of a single toolchain [`check`] run.
 //!
-//! [`check`]: crate::check::Check
+//! [`check`]: crate::compatibility::IsCompatible
 
 use crate::rust::Toolchain;
 use rust_releases::semver;
 
 #[derive(Clone, Debug)]
-pub enum Outcome {
-    Success(SuccessOutcome),
-    Failure(FailureOutcome),
+pub enum Compatibility {
+    Compatible(Compatible),
+    Incompatible(Incompatible),
 }
 
-impl Outcome {
+impl Compatibility {
     pub fn new_success(toolchain_spec: Toolchain) -> Self {
-        Self::Success(SuccessOutcome { toolchain_spec })
+        Self::Compatible(Compatible { toolchain_spec })
     }
 
     pub fn new_failure(toolchain_spec: Toolchain, error_message: String) -> Self {
-        Self::Failure(FailureOutcome {
+        Self::Incompatible(Incompatible {
             toolchain_spec,
             error_message,
         })
@@ -25,33 +25,33 @@ impl Outcome {
 
     pub fn is_success(&self) -> bool {
         match self {
-            Self::Success { .. } => true,
-            Self::Failure { .. } => false,
+            Self::Compatible { .. } => true,
+            Self::Incompatible { .. } => false,
         }
     }
 
     pub fn version(&self) -> &semver::Version {
         match self {
-            Self::Success(outcome) => outcome.toolchain_spec.version(),
-            Self::Failure(outcome) => outcome.toolchain_spec.version(),
+            Self::Compatible(outcome) => outcome.toolchain_spec.version(),
+            Self::Incompatible(outcome) => outcome.toolchain_spec.version(),
         }
     }
 
     pub fn toolchain_spec(&self) -> &Toolchain {
         match self {
-            Self::Success(outcome) => &outcome.toolchain_spec,
-            Self::Failure(outcome) => &outcome.toolchain_spec,
+            Self::Compatible(outcome) => &outcome.toolchain_spec,
+            Self::Incompatible(outcome) => &outcome.toolchain_spec,
         }
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct SuccessOutcome {
+pub struct Compatible {
     pub(crate) toolchain_spec: Toolchain,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct FailureOutcome {
+pub struct Incompatible {
     pub(crate) toolchain_spec: Toolchain,
     pub(crate) error_message: String,
 }
@@ -59,7 +59,7 @@ pub struct FailureOutcome {
 #[cfg(test)]
 mod tests {
     use crate::rust::Toolchain;
-    use crate::Outcome;
+    use crate::Compatibility;
     use rust_releases::semver;
 
     #[test]
@@ -67,7 +67,7 @@ mod tests {
         let version = semver::Version::new(1, 2, 3);
         let toolchain = Toolchain::new(version, "x", &[]);
 
-        let outcome = Outcome::new_success(toolchain.clone());
+        let outcome = Compatibility::new_success(toolchain.clone());
 
         assert!(outcome.is_success());
         assert_eq!(outcome.version(), &semver::Version::new(1, 2, 3));
@@ -79,7 +79,7 @@ mod tests {
         let version = semver::Version::new(1, 2, 3);
         let toolchain = Toolchain::new(version, "x", &[]);
 
-        let outcome = Outcome::new_failure(toolchain.clone(), "msg".to_string());
+        let outcome = Compatibility::new_failure(toolchain.clone(), "msg".to_string());
 
         assert!(!outcome.is_success());
         assert_eq!(outcome.version(), &semver::Version::new(1, 2, 3));

--- a/src/rust/setup_toolchain.rs
+++ b/src/rust/setup_toolchain.rs
@@ -47,10 +47,10 @@ fn install_toolchain(toolchain: &Toolchain) -> TResult<()> {
         .with_stdout()
         .with_stderr()
         .with_args([
+            "--no-self-update",
             "--profile",
             "minimal",
             &format!("{}", toolchain.version()),
-            "--no-self-update",
         ])
         .install()?;
 

--- a/src/rust/setup_toolchain.rs
+++ b/src/rust/setup_toolchain.rs
@@ -46,7 +46,12 @@ fn install_toolchain(toolchain: &Toolchain) -> TResult<()> {
     let rustup = RustupCommand::new()
         .with_stdout()
         .with_stderr()
-        .with_args(["--profile", "minimal", &format!("{}", toolchain.version())])
+        .with_args([
+            "--profile",
+            "minimal",
+            &format!("{}", toolchain.version()),
+            "--no-self-update",
+        ])
         .install()?;
 
     let status = rustup.exit_status();

--- a/src/search_method/linear.rs
+++ b/src/search_method/linear.rs
@@ -18,7 +18,11 @@ impl<'runner, R: IsCompatible> Linear<'runner, R> {
         Self { runner }
     }
 
-    fn run_check(runner: &R, release: &RustRelease, _reporter: &impl Reporter) -> TResult<Compatibility> {
+    fn run_check(
+        runner: &R,
+        release: &RustRelease,
+        _reporter: &impl Reporter,
+    ) -> TResult<Compatibility> {
         let toolchain = release.to_toolchain_spec();
         runner.is_compatible(&toolchain)
     }

--- a/src/sub_command/find/mod.rs
+++ b/src/sub_command/find/mod.rs
@@ -1,6 +1,6 @@
 use rust_releases::{Release, ReleaseIndex};
 
-use crate::check::Check;
+use crate::compatibility::IsCompatible;
 use crate::context::{FindContext, SearchMethod};
 use crate::error::{CargoMSRVError, NoToolchainsToTryError, TResult};
 use crate::manifest::bare_version::BareVersion;
@@ -14,12 +14,12 @@ use crate::writer::toolchain_file::write_toolchain_file;
 use crate::writer::write_msrv::write_msrv;
 use crate::{semver, SubCommand};
 
-pub struct Find<'index, C: Check> {
+pub struct Find<'index, C: IsCompatible> {
     release_index: &'index ReleaseIndex,
     runner: C,
 }
 
-impl<'index, C: Check> Find<'index, C> {
+impl<'index, C: IsCompatible> Find<'index, C> {
     pub fn new(release_index: &'index ReleaseIndex, runner: C) -> Self {
         Self {
             release_index,
@@ -28,7 +28,7 @@ impl<'index, C: Check> Find<'index, C> {
     }
 }
 
-impl<'index, C: Check> SubCommand for Find<'index, C> {
+impl<'index, C: IsCompatible> SubCommand for Find<'index, C> {
     type Context = FindContext;
     type Output = semver::Version;
 
@@ -41,7 +41,7 @@ fn find_msrv(
     ctx: &FindContext,
     reporter: &impl Reporter,
     release_index: &ReleaseIndex,
-    runner: &impl Check,
+    runner: &impl IsCompatible,
 ) -> TResult<semver::Version> {
     let search_result = search(ctx, reporter, release_index, runner)?;
 
@@ -89,7 +89,7 @@ fn search(
     ctx: &FindContext,
     reporter: &impl Reporter,
     index: &ReleaseIndex,
-    runner: &impl Check,
+    runner: &impl IsCompatible,
 ) -> TResult<MinimumSupportedRustVersion> {
     let releases = index.releases();
 
@@ -111,7 +111,7 @@ fn run_with_search_method(
     ctx: &FindContext,
     included_releases: &[Release],
     reporter: &impl Reporter,
-    runner: &impl Check,
+    runner: &impl IsCompatible,
 ) -> TResult<MinimumSupportedRustVersion> {
     let search_method = ctx.search_method;
     info!(?search_method);

--- a/src/sub_command/find/tests.rs
+++ b/src/sub_command/find/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::check::TestRunner;
+use crate::compatibility::TestRunner;
 use crate::context::{
     CheckCommandContext, EnvironmentContext, ReleaseSource, RustReleasesContext, ToolchainContext,
     WorkspacePackages,

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -5,10 +5,10 @@
 
 use std::collections::HashSet;
 
-use cargo_msrv::check::Check;
+use cargo_msrv::compatibility::IsCompatible;
 use cargo_msrv::error::CargoMSRVError;
 use cargo_msrv::rust::Toolchain;
-use cargo_msrv::Outcome;
+use cargo_msrv::Compatibility;
 use rust_releases::semver::Version;
 
 pub struct TestRunner {
@@ -25,19 +25,19 @@ impl TestRunner {
     }
 }
 
-impl Check for TestRunner {
-    fn check(&self, toolchain: &Toolchain) -> Result<Outcome, CargoMSRVError> {
+impl IsCompatible for TestRunner {
+    fn is_compatible(&self, toolchain: &Toolchain) -> Result<Compatibility, CargoMSRVError> {
         let version = toolchain.version();
         let components = toolchain.components();
 
         if self.accept_versions.contains(toolchain.version()) {
-            Ok(Outcome::new_success(Toolchain::new(
+            Ok(Compatibility::new_success(Toolchain::new(
                 version.clone(),
                 self.target,
                 components,
             )))
         } else {
-            Ok(Outcome::new_failure(
+            Ok(Compatibility::new_failure(
                 Toolchain::new(version.clone(), self.target, components),
                 "f".to_string(),
             ))

--- a/tests/common/sub_cmd_find.rs
+++ b/tests/common/sub_cmd_find.rs
@@ -1,6 +1,6 @@
 use crate::common::reporter::EventTestDevice;
-use cargo_msrv::compatibility::RustupToolchainCheck;
 use cargo_msrv::cli::CargoCli;
+use cargo_msrv::compatibility::RustupToolchainCheck;
 use cargo_msrv::error::CargoMSRVError;
 use cargo_msrv::reporter::{Message, SubcommandResult};
 use cargo_msrv::{Context, Find, SubCommand};

--- a/tests/common/sub_cmd_find.rs
+++ b/tests/common/sub_cmd_find.rs
@@ -1,5 +1,5 @@
 use crate::common::reporter::EventTestDevice;
-use cargo_msrv::check::RustupToolchainCheck;
+use cargo_msrv::compatibility::RustupToolchainCheck;
 use cargo_msrv::cli::CargoCli;
 use cargo_msrv::error::CargoMSRVError;
 use cargo_msrv::reporter::{Message, SubcommandResult};

--- a/tests/common/sub_cmd_verify.rs
+++ b/tests/common/sub_cmd_verify.rs
@@ -1,5 +1,5 @@
 use crate::common::reporter::EventTestDevice;
-use cargo_msrv::check::RustupToolchainCheck;
+use cargo_msrv::compatibility::RustupToolchainCheck;
 use cargo_msrv::cli::CargoCli;
 use cargo_msrv::error::CargoMSRVError;
 use cargo_msrv::{Context, SubCommand, Verify};

--- a/tests/common/sub_cmd_verify.rs
+++ b/tests/common/sub_cmd_verify.rs
@@ -1,6 +1,6 @@
 use crate::common::reporter::EventTestDevice;
-use cargo_msrv::compatibility::RustupToolchainCheck;
 use cargo_msrv::cli::CargoCli;
+use cargo_msrv::compatibility::RustupToolchainCheck;
 use cargo_msrv::error::CargoMSRVError;
 use cargo_msrv::{Context, SubCommand, Verify};
 use rust_releases::{Release, ReleaseIndex};


### PR DESCRIPTION
In #1036, an issue was reported which reported toolchain install issues, possibly caused by path separator issues on windows (ubuntu and mac seem to be fine).

With this commit, we add a run of cargo-msrv as an e2e test to our own CI on windows and mac while we're at it. Previously, we would only run on ubuntu; the e2e test was a side-effect of checking our own MSRV. We do have tests which run via the 'cargo run' vehicle and temporary directories, but that's not as sandboxed as this approach.

Hopefully, running all primary platforms will (1) give an indication of whether #1036 is indeed a cargo-msrv issue, and (2) prevent similar bugs in the future.