### PR TITLE
Fix outdated docs which said that linear was default

### DIFF
--- a/book/src/commands/find.md
+++ b/book/src/commands/find.md
@@ -19,7 +19,7 @@ available and of course the limiting factor of the project which will determine 
 cargo-msrv _check_. By default, the check command, the command used to test whether toolchain passes or fails a check,
 is `cargo check`.
 
-There are currently two search strategies: _linear_ (default) and _bisect_. Linear tests projects against toolchains in
+There are currently two search strategies: _bisect_ (default) and _linear_. Linear tests projects against toolchains in
 a
 most-recent to least-recent order. When a check fails, the previous Rust (if any) version is returned as the MSRV (i.e.
 the highest still

--- a/book/src/index.md
+++ b/book/src/index.md
@@ -29,7 +29,7 @@ and of course the limiting factor of the project which will determine the MSRV. 
 cargo-msrv _check_. By default, the check command, the command used to test whether toolchain passes or fails a check,
 is `cargo check`.
 
-There are currently two search strategies: _linear_ and _bisect_ (default). When using the linear strategy, your crate
+There are currently two search strategies: _bisect_ (default) and _linear_. When using the linear strategy, your crate
 will be checked against toolchains from most-recent to least-recent. When a check fails, the previous Rust (if any)
 version is returned as the MSRV (i.e. the highest toolchain for which a check command passes). The bisect strategy uses
 a binary search to find the MSRV. This can be significantly faster, so it's usually advisable to keep it enabled by


### PR DESCRIPTION
Also changes the terms of a sentence in `book/src/index.md` to make the default one come first, for consistency with other similar sentences in the docs. Closes #1042.