### PR TITLE
find: Add --set as alias of --write-msrv

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -164,7 +164,7 @@ pub struct FindOpts {
     /// For toolchains which include a Cargo version which supports the rust-version field,
     /// the `package.rust-version` field will be written. For older Rust toolchains,
     /// the `package.metadata.msrv` field will be written instead.
-    #[arg(long)]
+    #[arg(long, visible_alias = "set")]
     pub write_msrv: bool,
 
     #[command(flatten)]


### PR DESCRIPTION
Introduce --set as an alias for the --write-msrv option in `cargo msrv find` to maintain consistency with `cargo msrv set`.

Closes #1047.