### PR TITLE
Accept same licenses in cargo-deny and cargo-about

### DIFF
--- a/about.toml
+++ b/about.toml
@@ -1,10 +1,13 @@
 accepted = [
+    "0BSD",
     "Apache-2.0",
     "BSD-3-Clause",
     "ISC",
     "MIT",
+    "OpenSSL",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
     "Zlib",
-    "0BSD",
 ]
 workarounds = ["ring", "rustls"]
 


### PR DESCRIPTION
Should fix automated release build, which failed for 0.17.0
