### PR TITLE
ci: build binaries on ubuntu 22.04 instead of latest

### DIFF
--- a/.github/workflows/build-release-binaries.yaml
+++ b/.github/workflows/build-release-binaries.yaml
@@ -11,11 +11,11 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04 # Prevent building on the latest GLIBC. There's not really a need to, and Debian 12 users are still behind
             archive_ext: tgz
 
           - target: x86_64-unknown-linux-musl
-            os: ubuntu-latest
+            os: ubuntu-22.04 # Prevent building on the latest GLIBC. There's not really a need to, and Debian 12 users are still behind
             archive_ext: tgz
 
           - target: x86_64-apple-darwin


### PR DESCRIPTION
The compiled binaries require `GLIBC_2.32` to run when compiled on ubuntu latest. Which makes distros that are a bit behind (like Debian 12, which github codespaces are still running on) not able to run it out of the box

Switching to ubuntu 22.04 brings the requirement down