### PR TITLE
Switch the `rust-releases-dist-source` feature off by default.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ tracing-appender = "0.2" # tracing
 tracing-subscriber = { version = "0.3", features = ["json"] }
 
 [features]
-default = ["rust-releases-dist-source"]
 rust-releases-dist-source = ["rust-releases/rust-dist"]
 
 [dev-dependencies]


### PR DESCRIPTION
Justification: enabling this almost doubles the dependency count, takes it from ~200 to ~400.
The `cargo test` results on my machine improved after this change. The `rust-releases` crate also recommends using the changelog source. The increase in compilation time is more than double, because all the aws crates take a very long time to compile.

A pull request for this was created once already: #628, but it was closed without explanation. I thought I might as well open a PR instead of an issue since I want to ask why :^)