### PR TITLE
Style help text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "dirs",
  "dunce",
  "indicatif",
+ "indoc",
  "msrv",
  "owo-colors",
  "parameterized",
@@ -1839,6 +1840,12 @@ dependencies = [
  "unicode-width 0.2.0",
  "web-time",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "is_terminal_polyfill"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ clap-cargo = { version = "0.15.2", features = ["cargo_metadata"] }
 dirs = "6.0.0" # common directories
 dunce = "1.0.5" # better canonicalize for Windows
 indicatif = "0.17.11" # UI
+indoc = "2.0.6"
 owo-colors = "4.1.0" # color support for the terminal
 petgraph = "0.8.1" # graph data structures
 rust-releases = { version = "0.30.0", default-features = false, features = ["rust-changelog"] } # get the available rust versions

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -67,7 +67,7 @@ pub enum CargoMsrvCli {
     /// Find your Minimum Supported Rust Version!
     #[command(
         author = "Martijn Gribnau <garm@ilumeo.com>",
-        after_help = r#"
+        after_help = indoc::indoc!{"
             You can provide a custom compatibility check command as the last positional argument via
             the -- syntax, e.g. `$ cargo msrv find -- my custom command`.
 
@@ -79,7 +79,7 @@ pub enum CargoMsrvCli {
             NB: You only need to provide the <COMMAND...> part.
 
             By default, the compatibility check command is `cargo check`.
-        "#
+        "}
     )]
     Msrv(CargoMsrvOpts),
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ use crate::cli::toolchain_opts::ToolchainOpts;
 use crate::context::list::ListMsrvVariant;
 use crate::manifest::bare_version::BareVersion;
 use clap::{Args, Parser, Subcommand};
+use clap_cargo::style::CLAP_STYLING;
 use std::ffi::{OsStr, OsString};
 
 pub(crate) mod custom_check_opts;
@@ -13,7 +14,7 @@ pub(crate) mod shared_opts;
 pub(crate) mod toolchain_opts;
 
 #[derive(Debug, Parser)]
-#[command(version, name = "cargo", bin_name = "cargo", max_term_width = 120)]
+#[command(version, name = "cargo", bin_name = "cargo", max_term_width = 120, styles = CLAP_STYLING)]
 pub struct CargoCli {
     #[command(subcommand)]
     subcommand: CargoMsrvCli,


### PR DESCRIPTION
This PR colorizes the help text with the same colors that Cargo uses and unindents the help text which is shown after the usage so that it doesn't look weirdly offset compared to the options.

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/654668bf-529e-415e-bb8f-2d8802e2d562" />

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/c4fd9019-ea57-47ad-9f4d-c7d963ee808b" />

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/f902d5de-3b01-4ce7-bd8c-b8350c4a5bf5" />
