### PR TITLE
Group cargo_metadata and clap-cargo dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
   open-pull-requests-limit: 10
   labels:
     - C-dependency-update
+  groups:
+    cargo_metadata:
+      patterns:
+        - "cargo_metadata"
+        - "clap-cargo"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
clap-cargo depends on cargo_metadata and its version needs to be in sync otherwise the types won't match (for rustc).