### PR TITLE
Use x86_64-unknown-linux-musl target in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
+RUN apk add git # add git for embedded metadata via `vergen`
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
 RUN cargo build --verbose --locked --release


### PR DESCRIPTION
Should prevent the following errors which happen to pop up after some time of not upgrading:

cargo-msrv: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by cargo-msrv)
cargo-msrv: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by cargo-msrv)

fixes #816
fixes #1235
