### PR TITLE
clippy: fix useless_borrows_in_formatting lint

### DIFF
--- a/crates/msrv/src/msrv.rs
+++ b/crates/msrv/src/msrv.rs
@@ -28,7 +28,7 @@ impl MSRV {
 
 impl fmt::Display for MSRV {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!("{}", &self.version))
+        f.write_fmt(format_args!("{}", self.version))
     }
 }
 

--- a/src/reporter/event/termination.rs
+++ b/src/reporter/event/termination.rs
@@ -22,7 +22,7 @@ impl TerminateWithFailure {
         Self {
             highlight,
             reason: SerializableReason {
-                description: format!("{}", &error),
+                description: format!("{}", error),
             },
         }
     }

--- a/src/reporter/ui/json/mod.rs
+++ b/src/reporter/ui/json/mod.rs
@@ -57,6 +57,6 @@ impl<W: SendWriter> EventHandler for JsonHandler<W> {
         let mut w = self.writer.lock().expect(Self::LOCK_FAILURE_MSG);
         let serialized_event = serde_json::to_string(&event).expect(Self::SERIALIZE_FAILURE_MSG);
 
-        writeln!(&mut w, "{}", &serialized_event).expect(Self::WRITE_FAILURE_MSG);
+        writeln!(&mut w, "{}", serialized_event).expect(Self::WRITE_FAILURE_MSG);
     }
 }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting